### PR TITLE
Change [40] Better Ad Vic projectile type and shot velocity to improve kill credit

### DIFF
--- a/docs/items/weapon-configs.md
+++ b/docs/items/weapon-configs.md
@@ -510,9 +510,9 @@ The configurations that make up each of the custom weapons.
     - Weapon Damage: 1.30
 - Config: Projectile
     - Shot Count: 2
-    - Shot Velocity: 100
+    - Shot Velocity: 115
     - Porjectile Config: 3
-    - Projectile: M41 Tracker Rocket
+    - Projectile: M41 SPNKr Rocket
 - Ammo: Boost (34)
     - 2+4
 - REQ Tier: 8


### PR DESCRIPTION
## Changed

**Adjusted**
- [40] Better Ad Vic, REQ 8
    - Projectile: M41 Tracker Rocket -> M41 SPNKr Rocket
    - Shot Velocity: 100 -> 115

 ## Reasoning

**[40] Projectile change**
The M41 Tracker Rocket is slow at the start, but speeds up later. This results in the M41 Tracker Rocket shots impacting long-distance targets before the real rocket and killing players, not granting the shooter kill credit.
Changing to the M41 SPNKr Rocket projectile and adjusting the shot velocity has the two cloned rockets follow the nearly same speed as the real rocket, but lack slightly behind so the real rocket can hit enemies first and grant kill credit.