### PR TITLE
Remove Harbinger Weapon and redesignate Brute Scrap Cannon number

### DIFF
--- a/docs/items/weapon-configs.md
+++ b/docs/items/weapon-configs.md
@@ -384,7 +384,7 @@ The configurations that make up each of the custom weapons.
 * Game State: 6
 * Notes: -  
   
-## [31] Scrap Cannon (Answer)
+## [31] The Answer
 * Weapon Type: Scrap Cannon + Diminisher Of Hope
 * Trait Set: 31
   * Weapon Damage: 1.70
@@ -397,7 +397,16 @@ The configurations that make up each of the custom weapons.
 * Game State: 4
 * Notes: -
 
-## [32] -
+## [32] Brute Scrap Cannon
+- Weapon Type: Brute Scrap Cannon
+- Trait Set: 32
+    - Weapon Damage: 1.00
+- Config: Default
+- Ammo: Default
+    - 100%
+- REQ Tier: 2
+- Game State: 1
+- Notes: -
 
 ## [33] Barrage Cannon
 * Weapon Type: Plasma Cannon + Unbound Plasma Pistol
@@ -641,25 +650,3 @@ The configurations that make up each of the custom weapons.
 - REQ Tier: 8
 - Game State: 6
 - Notes: Damage output based off of secondary fire strength; primary fire is not as effective.
-
-## [50] Harbinger's Weapon
-- Weapon Type: Harbinger Primary
-- Trait Set: 50
-    - Weapon Damage: 3.00
-- Config: Default
-- Ammo: Default
-    - 100%
-- REQ Tier: 9
-- Game State: 6
-- Notes: -
-
-## [51] Brute Scrap Cannon
-- Weapon Type: Brute Scrap Cannon
-- Trait Set: 51
-    - Weapon Damage: 1.00
-- Config: Default
-- Ammo: Default
-    - 100%
-- REQ Tier: 2
-- Game State: 1
-- Notes: -


### PR DESCRIPTION
## Changes

**Removed**
- [50] Harbinger Weapon, REQ 9

**Adjusted**
- [51] Brute Scrap Cannon, REQ 2 -> [32] Brute Scrap Cannon

## Reasoning

**Harbinger Weapon removal**
The Harbinger's Weapon which was pitched as a REQ 9 weapon in https://github.com/The-Scripters-Guild/Warzone/pull/20 for it being a potential viable weapon turned out to have an issue where the shot projectiles would prematurely explode before reaching the target, rendering the weapon useless and a waste of REQ points.

**Brute Scrap Cannon change**
As the [32] BurstCannon was removed in https://github.com/The-Scripters-Guild/Warzone/pull/21 and now the [50] Harbinger Weapon removed, it left the [51] Brute Scrap Cannon hanging off from the rest of the designated numbers, so it was relocated to 32.
This early in development this change should not have any negative impact on existing scripting, as long as the frameworks are updated to account for the number change in due course.