### PR TITLE
docs: armor-mod-config is severely behind.

### DIFF
--- a/docs/items/armor-mod-configs.md
+++ b/docs/items/armor-mod-configs.md
@@ -135,7 +135,7 @@ The configurations that make up each of the armor modifications.
   - M392 Bandit (15/30 -> 15/45)
   - BR75 (36/108 -> 36/216)
   - VK78 Commando (20/60 -> 20/120)
-  - MA5K Avenger (? -> ?)
+  - MA5K Avenger (60/180 -> 60/300)
   - Mk50 Sidekick + MA40 Longshot (25/75 -> 25/150)
   - MA40 Assault Rifle + Arcane Sentinel Beam (80/80 -> 80/240)
   - BR75 + Arcane Sentinel Beam (80/80 -> 80/240)
@@ -143,17 +143,16 @@ The configurations that make up each of the armor modifications.
 
 ## [M8] Frag Grenade Operator
 * Game State: 2
-* Notes: Adjusts the player's Frag Grenade count by 2
+* Notes: Sets the player's Frag Grenade count to 4 and removes all other Grenades.
 
 ## [M9] Spike Grenade Operator
 * Game State: 2
-* Notes: Adjusts the player's Spike Grenade count by 2
+* Notes: Sets the player's Frag Grenade count to 2, Spike Grenade count to 2 and removes all other Grenades.
 
 ## [M10] Plasma Grenade Operator
 * Game State: 3
-* Notes: Adjusts the player's Plasma Grenade count by 2
+* Notes: Sets the player's Frag Grenade count to 2, Plasma Grenade count to 2 and removes all other Grenades.
 
 ## [M11] Dynamo Grenade Operator
 * Game State: 5
-* Notes: Adjusts the player's Dynamo Grenade count by 2
-
+* Notes: Sets the player's Frag Grenade count to 2, Dynamo Grenade count to 2 and removes all other Grenades.

--- a/docs/items/armor-mod-configs.md
+++ b/docs/items/armor-mod-configs.md
@@ -57,19 +57,19 @@ The configurations that make up each of the armor modifications.
 * Notes: -
 -->
 
-## [M1] Auto-Medic
-* Trait Set: autoMedic
+## [M1] Heal Boost
+* Trait Set: healBoost
   * Health Recharge
     * Recharge Delay Scalar: -0.30 (5.0 s -> 3.5 s to begin recharging = 30.0% faster)
     * Recharge Rate Scalar: 0.42 (1.1333 s -> 0.798098591549 s to charge fully = 29.5% faster)
   * Shield Recharge
     * Recharge Delay Scalar: -0.30 (5.0 s -> 3.5 s to begin recharging = 30.0% faster)
     * Recharge Rate Scalar: 0.42 (2.0 s -> 1.40845070423 s to charge fully = 29.5% faster)
-* Game State: ?
+* Game State: 3
 * Notes: Explanation on how to adjust the scalars: https://discord.com/channels/220766496635224065/1275401201973854238/1275437779370639420
 
-## [M2] Advanced Sensors
-* Trait Set: advancedSensors
+## [M2] Upgraded Sensor
+* Trait Set: upgradedSensor
   * Motion Tracker Visible
     * Motion Tracker Enabled: TRUE
     * Enabled While Zooming: TRUE
@@ -77,18 +77,18 @@ The configurations that make up each of the armor modifications.
     * Inner Ring Scalar: 1.35
     * Extended Range Scalar: 1.10
     * Vehicle Range Scalar: 1.00
-* Game State: ?
+* Game State: 4
 * Notes: Inner Ring is a general extension of the range and Extended Range is how far enemies will be shown on the outside ring of the radar when they're not within the range of the Inner Ring.
 
-## [M3] Reflex Enhancers
-* Trait Set: reflexEnhancers
+## [M3] Rush
+* Trait Set: rush
   * Reload Speed
     * Empty Reload Scalar: 1.17
     * Tactical Reload Scalar: 1.17
   * Weapon Switch Speed: 1.17
   * Clamber Speed: 1.17
   * Melee Recovery Speed: 1.10
-* Game State: ?
+* Game State: 3
 * Notes: -
 
 ## [M4] Grenadier
@@ -99,22 +99,35 @@ The configurations that make up each of the armor modifications.
     * Explosive Damage Scalar: 1.00
   * Grenade Damage: 1.10
   * Grenade Detonation Radius: 1.52
-* Game State: ?
+* Game State: 2
 * Notes: -
 
-## [M5] Upgraded Sprint
-* Trait Set: upgradedSprint
+## [M5] Upgraded Walking
+* Trait Set: upgradedWalking
+  * Movement Speed: 1.10
+  * Jump Height: 1.10
   * Sprint Speed
-    * Top Speed Scalar: 1.10
+    * Top Speed Scalar: 0.95
+    * Time To Top Speed Scalar: 1.00
+  * Slide Speed
+    * Slide Speed Scalar: 0.93
+    * Slide Duration Scalar: 1.00
+* Game State: 3
+* Notes: -
+
+## [M6] Upgraded Sprinting
+* Trait Set: upgradedSprinting
+  * Sprint Speed
+    * Top Speed Scalar: 1.13
     * Time To Top Speed Scalar: 0.90
   * Slide Speed
     * Slide Speed Scalar: 1.10
-    * Slide Duration Scalar: 1.10
-* Game State: ?
+    * Slide Duration Scalar: 1.00
+* Game State: 3
 * Notes: -
 
-## [M6] Patrol Case
-* Game State: ?
+## [M7] Patrol Case
+* Game State: 2
 * Notes: Gives the maximum amount of ammo for any equipped loadout weapons at the time of equip. The list of affected weapon types is:
   - MA40 Assault Rifle (36/108 -> 36/216)
   - Mk50 Sidekick (12/36 -> 12/72)
@@ -128,19 +141,19 @@ The configurations that make up each of the armor modifications.
   - BR75 + Arcane Sentinel Beam (80/80 -> 80/240)
   - VK78 Commando Rifle + Arcane Sentinel Beam (80/80 -> 80/240)
 
-## [M7] Frag Grenade Expert
-* Game State: ?
+## [M8] Frag Grenade Operator
+* Game State: 2
 * Notes: Adjusts the player's Frag Grenade count by 2
 
-## [M8] Spike Grenade Expert
-* Game State: ?
+## [M9] Spike Grenade Operator
+* Game State: 2
 * Notes: Adjusts the player's Spike Grenade count by 2
 
-## [M9] Plasma Grenade Expert
-* Game State: ?
+## [M10] Plasma Grenade Operator
+* Game State: 3
 * Notes: Adjusts the player's Plasma Grenade count by 2
 
-## [M10] Dynamo Grenade Expert
-* Game State: ?
+## [M11] Dynamo Grenade Operator
+* Game State: 5
 * Notes: Adjusts the player's Dynamo Grenade count by 2
 


### PR DESCRIPTION
The dev names we were using for the armor mods are no longer needed. They have been updated to their new names we made using the "string" words that we have access to in forge.

We came to the conclusion of what game states the armor mods were going to be unlocked. This has been updated as well.

Upgraded Walking has now been fully tested and so it was required to be added. While Upgraded Walking gives you a passive boost to your strafe and or walking speed, Upgraded Sprinting is focused on giving you a passive boost to your actual sprint speed. These two armor mods function as inverse of each other and come with other added benfits that the other does not receive.