### PR TITLE
feat: Remove dev names for powerups

### DIFF
--- a/docs/items/powerup-configs.md
+++ b/docs/items/powerup-configs.md
@@ -61,9 +61,9 @@ The configurations that make up each of the custom powerups.
 * Notes: -
 -->
 
-## [E1] Vampirism
+## [E1] Health Steal
 * Equipment Type: Custom Equipment A
-* Trait Set: vampirism
+* Trait Set: healthSteal
   * Vampirism
     * Shield Scalar: 0.00
     * Health Scalar: 0.40
@@ -73,9 +73,9 @@ The configurations that make up each of the custom powerups.
 * Game State: 5
 * Notes: Vampirism only comes from dealing damage to enemy health, not shield.
 
-## [E2] Melee Boost
+## [E2] Power Arm
 * Equipment Type: Custom Equipment B
-* Trait Set: meleeBoost
+* Trait Set: powerArm
   * Melee Impulse: 2.00
   * Melee Recovery Speed: 1.80
 * Duration: 45 s
@@ -101,9 +101,9 @@ The configurations that make up each of the custom powerups.
 * Game State: 1
 * Notes: Slightly faster speed which is noticeable when sliding.
 
-## [E4] Headshot Protection
+## [E4] Headhunter Guard
 * Equipment Type: Custom Equipment D
-* Trait Set: headshotProtection
+* Trait Set: headhunterGuard
   * Headshot Protection: TRUE
 * Duration: 60 s
 * VFX: VIP

--- a/docs/items/powerup-configs.md
+++ b/docs/items/powerup-configs.md
@@ -86,20 +86,30 @@ The configurations that make up each of the custom powerups.
 
 ## [E3] Speed Boost
 * Equipment Type: Custom Equipment C
-* Trait Set: speedBoost
+* Trait Set 1: upgradedWalkingPU
   * Movement Speed: 1.10
   * Jump Height: 1.10
   * Sprint Speed
-    * Top Speed Scalar: 1.01
+    * Top Speed Scalar: 0.95
     * Time To Top Speed Scalar: 1.00
   * Slide Speed
+    * Slide Speed Scalar: 0.93
+    * Slide Duration Scalar: 1.00
+  * Slide Speed
     * Slide Speed Scalar: 0.99
+    * Slide Duration Scalar: 1.00
+* Trait Set 2: upgradedSprintingPU
+  * Sprint Speed
+    * Top Speed Scalar: 1.13
+    * Time To Top Speed Scalar: 0.90
+  * Slide Speed
+    * Slide Speed Scalar: 1.10
     * Slide Duration Scalar: 1.00
 * Duration: 45 s
 * VFX: None
 * REQ Tier: 2
 * Game State: 1
-* Notes: Slightly faster speed which is noticeable when sliding.
+* Notes: Combines the upgradedWalking and upgradedSprinting armor mods for the best of both. Trait sets are identical, but separate declarations so they can be individually turned on and off without intereference.
 
 ## [E4] Headhunter Guard
 * Equipment Type: Custom Equipment D


### PR DESCRIPTION
We are no longer in need of the dev names we have been using for the powerups as we have used the "string" words available in forge to create new names for them. They are now accurate and up to date.