### PR TITLE
feat: Update the chart to be current

### DIFF
--- a/docs/items/purhchases-start.md
+++ b/docs/items/purhchases-start.md
@@ -1,8 +1,8 @@
 # Purchases available at Gameplay Start
 
-| **REQ COST** | **1**                        | **2**                        | **3**                        | **4**                             | **5**                           | **6** | **7** | **8** | **9** |
-|:------------:|:----------------------------:|:----------------------------:|:----------------------------:|:---------------------------------:|:-------------------------------:|:-----:|:-----:|:-----:|:-----:|
-|              | Shroud Screen, 1 [Equipment] | Thruster, 3 [Equipment]      | Repair Field, 1 [Equipment]  | Grappleshot, 4 [Equipment]        | Grappleshot, Leg, 4 [Equipment] |       |       |       |       |
-|              |                              | Threat Sensor, 3 [Equipment] | Thruster, Leg, 3 [Equipment] | Threat Sensor, Leg, 2 [Equipment] | Drop Wall, Leg, 1 [Equipment]   |       |       |       |       |
-|              |                              | Drop Wall, 3 [Equipment]     | Repulsor, 4 [Equipment]      |                                   |                                 |       |       |       |       |
-|              |                              |                              |                              |                                   |                                 |       |       |       |       |
+| **REQ COST** | **1** | **2**                        | **3**                        | **4**                             | **5**                           | **6** | **7** | **8** | **9** |
+|:------------:|:-----:|:----------------------------:|:----------------------------:|:---------------------------------:|:-------------------------------:|:-----:|:-----:|:-----:|:-----:|
+|              |       | Thruster, 3 [Equipment]      | Repair Field, 1 [Equipment]  | Grappleshot, 4 [Equipment]        | Grappleshot, Leg, 4 [Equipment] |       |       |       |       |
+|              |       | Threat Sensor, 3 [Equipment] | Thruster, Leg, 3 [Equipment] | Threat Sensor, Leg, 2 [Equipment] | Drop Wall, Leg, 1 [Equipment]   |       |       |       |       |
+|              |       | Drop Wall, 3 [Equipment]     | Repulsor, 4 [Equipment]      |                                   |                                 |       |       |       |       |
+|              |       | Shroud Screen, 2 [Equipment] |                              |                                   |                                 |       |       |       |       |


### PR DESCRIPTION
Threat Sensor was removed since it is a redundant equipment.

Shroud screen has been bumped up in REQ cost to free up the REQ cost 1 column in order to free up space in our physical REQ wall