### PR TITLE
Scout Skewer overhaul; no reload 6 shots

### DIFF
--- a/docs/items/weapon-configs.md
+++ b/docs/items/weapon-configs.md
@@ -322,9 +322,9 @@ The configurations that make up each of the custom weapons.
 - Notes: -
 
 ## [27] Scout Skewer
-- Weapon Type: Skewer + Diminisher of Hope
+- Weapon Type: Skewer + Pursuit Hydra
 - Trait Set: 27
-  - Weapon Damage: 1.05
+  - Weapon Damage: 0.70
   - Movement Speed: 1.20
   - Jump Height: 1.30
   - Reload Speed
@@ -332,8 +332,8 @@ The configurations that make up each of the custom weapons.
     - Tactical Reload Scalar: 3.00
 - VFX: VIP
 - Config: Combo
-- Ammo Adjustment: None
-  - 1+3
+- Ammo Adjustment: -50
+  - 6+0
 - REQ Tier: 6
 - Game State: 5
 - Notes: -


### PR DESCRIPTION
## Changes

**Adjusted:**

- [27] Scout Skewer:
    - Weapon Type: Skewer + Diminisher of Hope -> Skewer + Pursuit Hydra
    - Weapon Damage: 1.05 -> 0.70
    - Ammo Adjustment: None (1+3) -> -50 (6+0)

## Scout Skewer overhaul

The Scout Skewer was underperforming at REQ tier 6 and was not a good pick against the Volatile Skewer at the same level. The weapon needed an overhaul to make it be more unique than just a faster Skewer. A special combo weapon of Pursuit Hydra was used that—presumably due to a bug—keeps the Skewer projectile, but inherits other traits of the Pursuit Hydra in the combo. The Weapon Damage of 0.70 gives it just about enough damage to still kill a player in one shot to the body, but limits the vehicle damage so that it can just about kill a Scorpion with 6 shots.

The new Scout Skewer requires the user to individually reload 6 shots in the magazine, but at the benefit of being able to fire multiple shots in quick succession without reloading. This special characteristic combined with the movement buffs makes the weapon live up to its name of being a faster Skewer.