### PR TITLE
AI Config- and encounter adjustment

### DIFF
--- a/docs/npc/ai-variants-custom.md
+++ b/docs/npc/ai-variants-custom.md
@@ -228,10 +228,10 @@ Documentation of all the custom AI variants used for the Warzone mode. Only the 
 * Primary Weapon Type: Pursuit Hydra
 * Trait Set: ?
   * Damage Resistance
-    * Direct Damage Scalar: 2.00
-    * Grenade Damage Scalar: 0.50
-    * Explosive Damage Scalar: 0.50
-* Notes: Is a Boss and has a health bar.
+    * Direct Damage Scalar: 1.00
+    * Grenade Damage Scalar: 1.50
+    * Explosive Damage Scalar: 1.50
+* Notes: Is a Boss and has a health bar. Weak to explosive plasma damage.
 
 ## [23] Boss Escharum
 

--- a/docs/npc/ai-variants-custom.md
+++ b/docs/npc/ai-variants-custom.md
@@ -200,9 +200,9 @@ Documentation of all the custom AI variants used for the Warzone mode. Only the 
 * Trait Set: ?
   * Damage Resistance
     * Direct Damage Scalar: 3.80
-    * Grenade Damage Scalar: 0.83
-    * Explosive Damage Scalar: 0.83
-* Notes: -
+    * Grenade Damage Scalar: 2.10
+    * Explosive Damage Scalar: 2.10
+* Notes: Will die in 4 direct M41 SPNKr rockets.
 
 ## [20] Brute Chieftain
 

--- a/docs/npc/ai-variants-custom.md
+++ b/docs/npc/ai-variants-custom.md
@@ -117,13 +117,14 @@ Documentation of all the custom AI variants used for the Warzone mode. Only the 
 ## [12] Boss Thav 'Sebarim
 
 ![AI preview](../../assets/ai-33.jpg)
+* Primary Weapon Type: Same as [[37] Spike Off Ordo 'Mal](https://github.com/The-Scripters-Guild/Warzone/blob/main/docs/items/weapon-configs.md#37-spike-off-ordo-mal) including projectile-related values.
 * Trait Set: ?
   * Weapon Damage: 1.30
   * Damage Resistance
     * Direct Damage Scalar: 1.30
     * Grenade Damage Scalar: 0.7692
     * Explosive Damage Scalar: 0.7692
-* Notes: Is a Boss and has a health bar.
+* Notes: Is a Boss and has a health bar. Drops a [[37] Spike Off Ordo 'Mal](https://github.com/The-Scripters-Guild/Warzone/blob/main/docs/items/weapon-configs.md#37-spike-off-ordo-mal) upon death and deletes the Cindershot + Arcane Sentinel Beam.
 
 ## [13] Hunter
 

--- a/docs/npc/ai-variants-custom.md
+++ b/docs/npc/ai-variants-custom.md
@@ -91,9 +91,9 @@ Documentation of all the custom AI variants used for the Warzone mode. Only the 
 * Trait Set: -
   * Damage Resistance
     * Direct Damage Scalar: 2.00
-    * Grenade Damage Scalar: 0.50
-    * Explosive Damage Scalar: 0.50
-* Notes: -
+    * Grenade Damage Scalar: 1.30
+    * Explosive Damage Scalar: 1.30
+* Notes: Will die in 4 direct M41 SPNKr rockets.
 
 ## [10] Elite Ultra
 

--- a/docs/npc/ai-variants-custom.md
+++ b/docs/npc/ai-variants-custom.md
@@ -98,7 +98,7 @@ Documentation of all the custom AI variants used for the Warzone mode. Only the 
 ## [10] Elite Ultra
 
 ![AI preview](../../assets/ai-28.jpg)
-* Primary Weapon Type: Stalker Rifle Ultra
+* Primary Weapon Type: Rapidfire Pulse Carbine
 * Trait Set: -
   * Damage Resistance
     * Direct Damage Scalar: 1.00

--- a/docs/npc/ai-variants-custom.md
+++ b/docs/npc/ai-variants-custom.md
@@ -109,7 +109,7 @@ Documentation of all the custom AI variants used for the Warzone mode. Only the 
 ## [11] Boss Ordo 'Mal
 
 ![AI preview](../../assets/ai-31.jpg)
-* Primary Weapon Type: Stalker Rifle
+* Primary Weapon Type: Heatwave
 * Secondary Weapon Type: None
 * Trait Set: -
 * Notes: Is a Boss and has a health bar.

--- a/docs/npc/ai-variants-custom.md
+++ b/docs/npc/ai-variants-custom.md
@@ -133,9 +133,9 @@ Documentation of all the custom AI variants used for the Warzone mode. Only the 
   * Weapon Damage: 0.70
   * Damage Resistance
     * Direct Damage Scalar: 0.40
-    * Grenade Damage Scalar: 1.75
-    * Explosive Damage Scalar: 0.40
-* Notes: Is a Boss and has a health bar. 3 direct Rocket Launcher Rockets will kill. 2 direct Rocket Launcher Rockets if hit in back. 5 Frag Grenades will kill.
+    * Grenade Damage Scalar: 4.00
+    * Explosive Damage Scalar: 0.70
+* Notes: Is a Boss and has a health bar. 2 direct M41 SPNkrs in the front or 1 in the back will kill. 2 well-placed Frag Grenades will kill.
 
 ## [14] Boss Myriad
 

--- a/docs/npc/ai-variants-custom.md
+++ b/docs/npc/ai-variants-custom.md
@@ -242,12 +242,8 @@ Documentation of all the custom AI variants used for the Warzone mode. Only the 
 ## [24] Boss Harbinger
 
 ![AI preview](../../assets/ai-66.jpg)
-* Trait Set: ?
-  * Damage Resistance
-    * Direct Damage Scalar: 4.00
-    * Grenade Damage Scalar: 0.25
-    * Explosive Damage Scalar: 0.25
-* Notes: Is a Boss and has a health bar.
+* Trait Set: -
+* Notes: Is a Boss and has a health bar. Has four stages of dealing damage to their shield, and then their health, before dying.
 
 ## Acknowledgements
 

--- a/docs/npc/ai-variants-custom.md
+++ b/docs/npc/ai-variants-custom.md
@@ -86,7 +86,7 @@ Documentation of all the custom AI variants used for the Warzone mode. Only the 
 ## [9] Elite Warlord
 
 ![AI preview](../../assets/ai-27.jpg)
-* Primary Weapon Type: Rapidfire Pulse Carbine
+* Primary Weapon Type: Stalker Rifle
 * Secondary Weapon Type: None
 * Trait Set: -
   * Damage Resistance

--- a/docs/npc/ai-variants-custom.md
+++ b/docs/npc/ai-variants-custom.md
@@ -189,9 +189,9 @@ Documentation of all the custom AI variants used for the Warzone mode. Only the 
 * Trait Set: ?
   * Damage Resistance
     * Direct Damage Scalar: 10.00
-    * Grenade Damage Scalar: 0.10
-    * Explosive Damage Scalar: 0.10
-* Notes: -
+    * Grenade Damage Scalar: 1.40
+    * Explosive Damage Scalar: 1.40
+* Notes: Will die in 4 direct M41 SPNKr rockets.
 
 ## [19] Brute Warlord
 

--- a/docs/npc/encounter-configs.md
+++ b/docs/npc/encounter-configs.md
@@ -70,9 +70,10 @@ The configurations of AI that make up each of the AI encounters.
 
 - Brute Berserker, Chosen (Boss)
 - Brute Chieftain
+- Elite Ultra
 - Brute Warrior
 - Brute Warrior
-- Jackal Raider
+- Brute Sniper, Heavy
 - Jackal Raider
 
 ## [8] Hunter Encounter, Mythic

--- a/docs/npc/encounter-configs.md
+++ b/docs/npc/encounter-configs.md
@@ -61,9 +61,10 @@ The configurations of AI that make up each of the AI encounters.
 - Wraith
 	- Brute Warrior
 - Brute Warlord
-- Brute Sniper, Heavy
 - Grunt Ultra
-- Grunt Ultra
+- Brute Chieftain
+- Brute Chieftain
+- Brute Chieftain
 
 ## [7] Brute 2 Encounter, Legendary
 


### PR DESCRIPTION
## Changes

**Adjusted:**

AI configs:
- [9] Elite Warlord:
	- Primary Weapon Type: Rapidfire Pulse Carbine -> Stalker Rifle
	- Damage Resistance
		- Grenade Damage Scalar: 0.50 -> 1.30
		- Explosive Damage Scalar: 0.50 -> 1.30
- [10] Elite Ultra:
	- Primary Weapon Type: Stalker Rifle Ultra -> Rapidfire Pulse Carbine
- [11] Boss Ordo 'Mal:
    - Primary Weapon Type: Stalker Rifle -> Heatwave
- [12] Boss Thav 'Sebarim:
	- Primary Weapon Type: Default (Arcane Sentinel Beam) -> [37] Spike Off Ordo 'Mal
- [13] Hunter:
	- Damage Resistance
		- Grenade Damage Scalar: 1.75 -> 4.00
		- Explosive Damage Scalar: 0.40 -> 0.70
- [18] Brute Sniper, Heavy:
	 - Damage Resistance
		 - Grenade Damage Scalar: 0.10 -> 1.40
		 - Explosive Damage Scalar: 0.10 -> 1.40
- [19] Brute Warlord:
	- Damage Resistance
		- Grenade Damage Scalar: 0.83 -> 2.10
		- Explosive Damage Scalar: 0.83 -> 2.10
- [22] Boss Tremonius:
	- Damage Resistance
		- Direct Damage Scalar: 2.00 -> 1.00
		- Grenade Damage Scalar: 0.50 -> 1.50
		- Explosive Damage Scalar: 0.50 -> 1.50
- [24] Boss Harbinger:
	- Damage Resistance
		- Direct Damage Scalar: 4.00 -> 1.00 (remove)
		- Grenade Damage Scalar: 0.25 -> 1.00 (remove)
		- Explosive Damage Scalar: 0.25 -> 1.00 (remove)

AI Encounters:
- [6] Brute 1 Encounter, Legendary:
	- Boss Tremonius (Boss)
	- Wraith
	    - Brute Warrior
	- Brute Warlord
	- Brute Sniper, Heavy (remove)
	- Grunt Ultra
	- Grunt Ultra (remove)
	- Brute Chieftain (add)
	- Brute Chieftain (add)
	- Brute Chieftain (add)
- [7] Brute 2 Encounter, Legendary
	- Brute Berserker, Chosen (Boss)
	- Brute Chieftain
	- Elite Ultra (add)
	- Brute Warrior
	- Brute Warrior
	- Brute Sniper, Heavy (add)
	- Jackal Raider
	- Jackal Raider (remove)

## Elite Warlord weapon change

We felt the Elite Warlord holding a Rapidfire Pulse Carbine made them less lethal, less effective, and gave their rank less respect. Following the [Stalker Rifle shuffle](https://github.com/The-Scripters-Guild/Warzone/pull/48), we placed the Stalker Rifle at REQ 5, which suits well for high-tier AI weapon drop.

We've swapped the Elite Warlord's weapon to the Stalker Rifle, making the AI unit a lethal long-range sentry that will stay alive for a long time, unless targeted. We feel this change makes the Elite Warlord as dangerous as a Brute Warlord, which is a good accomplishment in consistency of the AI difficulty communication for the players.

## Elite Ultra weapon change

After the [Stalker Rifle shuffle](https://github.com/The-Scripters-Guild/Warzone/pull/48), we realized that now some of our AI would give those out to players too early. The Elite Ultra held the Stalker Rifle Ultra, which is way too powerful to hold for an AI that appears in a Legendary encounter at the earliest.

We also felt that there weren't enough shield-breaking force in the Elite AI encounters, so we've decided to swap the Elite Ultra's weapon to the Rapidfire Pulse Carbine. Having multiple Elite Ultras with this weapon now deters players more as the weapon melts shields very quickly.

## Boss Ordo 'Mal weapon change

Following the [Stalker Rifle shuffle](https://github.com/The-Scripters-Guild/Warzone/pull/48), the Stalker Rifle was ranked higher than we were comfortable with a Silver boss dropping early on. We had also given the Stalker Rifle now to the Elite Warlord, and we didn't want to have two AI with the same weapons.

Due to these factors, we've decided to swap the Boss Ordo 'Mal's weapon to the Heatwave, which is a tier 4 weapon, and still fits for a silver Elite AI.

## Boss Thav 'Sebarim weapon change

The Arcane Sentinel Beam felt too weak in the hands of the Boss Thav 'Sebarim AI. Even though it's a lethal weapon, the AI didn't use it effectively to land shots on players. The AI would also exchange the weapon for loose Stalker Rifles nearby, which invalidated the effectiveness of the Arcane Sentinel Beam.

We decided to swap it out for one of our custom weapons, the [37] Spike Off Ordo 'Mal, which shoots Spike Grenade projectiles. We feel the weapon fits for an Elite boss, and is definitely a unique weapon to fight against, as well as something to want to scavenge after defeating the boss.

## Brute 1 Encounter, Legendary adjustment

After comparing all the Legendary AI encounters against each other, the Brute 1 encounter stood out as being too difficult. We've made some changes to the AI in order to transform this AI battle to be easier and also have a strategy to defeating it.

Tremonius is a special Brute boss as his armor can't be shot off to expose his head unlike regular Brutes. Due to this, he is extremely resistant to all kinds of damage regularly. We've adjusted his damage resistance traits to make explosive weapons be the most effective against him.

In order to be most efficient, one must first take down his shield and then damage him with grenades or explosive damage. We realized that a weapon type that can do these both is the Fuel Rod, and that there is the Grunt Ultra in the encounter who holds a lower variant of the Fuel Rod, the [38] Infiltrator Off Worlds. After realizing this, and seeing that this weapon can efficiently–and perfectly within the 10 supplied shots–take down Tremonius, we decided to morph the AI encounter around killing the Grunt Ultra and using their weapon against Tremonius.

As all the Fuel Rod-based weapons are effective at close to medium range, we've added three Brute Chieftains to make getting to this effective range more difficult to the players as long as these Brute Chieftains are alive. We have not had the chance to test this encounter fully with the Wraith, but hope that it doesn't change this close-range mentality too much.

## Brute 2 Encounter, Legendary adjustment

This encounter felt good for the most part, but that was because it's mostly focused on avoiding the rushing boss, and the fodder get left behind. We felt the fodder was being ignored a bit too much, so we've added some more variety to the encounter with the addition of an Elite Ultra and a Brute Sniper, Heavy to spice up the battles with the fodder a bit more, and to also provide some more valuable loot.

## Elite Warlord explosion resistance decrease

(Higher values on these scalars mean less resistance)
During a playtest with player "KimboSmiff", we noticed a higher than usual explosive damage resistance on the Elite Warlords than what we would've expected; using an entire Ravager's ammo capacity on one Elite Warlord didn't result in a kill.

We've adjusted the Elite Warlord's grenade- and explosive damage resistance to make the AI unit die in four total M41 SPNKr explosions, when earlier it was over 10. As this AI is a very high rank, we feel this is a good balance for how much firepower players would have when facing this AI.

## Hunter explosion resistance decrease

(Higher values on these scalars mean less resistance)
After comparing the Silver boss encounters, we noticed that the Hunters were too difficult to kill compared to the other Silver bosses. All the other bosses also had clear weaknesses with first taking out their shield, and then aiming for the head. The Hunters' only weak spot seemed to be shooting the exposed orange parts, but these were very difficult to get to in gameplay.

We've leaned hard into making explosive damage be effective against the Hunters, and so have decreased their grenade- and explosive damage resistance majorly. One can expect these amounts of ammunition to now kill a Hunter:
M41 SPNKr rockets: 3 -> 2 in-front & 2 -> 1 behind
Frag Grenades: 5 -> 2 (above or behind)

These also make the low-tier explosive weapons have more purpose as they are more effective against the Hunters than higher-tiered direct damage weapons.

## Brute Sniper, Heavy explosion resistance decrease

(Higher values on these scalars mean less resistance)
Keeping consistency with the Elite Warlord's explosion resistance adjustments, we've adjusted the Brute Sniper, Heavy's grenade- and explosive damage resistance to make the AI unit die in four total M41 SPNKr explosions, when earlier it was over 10. As this AI is a very high rank, we feel this is a good balance for how much firepower players would have when facing this AI.

## Brute Warlord explosion resistance decrease

(Higher values on these scalars mean less resistance)
Keeping consistency with the Elite Warlord's explosion resistance adjustments, we've adjusted the Brute Sniper, Heavy's grenade- and explosive damage resistance to make the AI unit die in four total M41 SPNKr explosions, when earlier it was over 10. As this AI is a very high rank, we feel this is a good balance for how much firepower players would have when facing this AI.

## Boss Tremonius overall damage resistance decrease

(Lower values on direct damage and higher values on grenade- and explosive scalars mean less resistance)
Detailed mostly already in the Brute 1 Encounter, Legendary adjustment changes, but Boss Tremonius felt way too strong even on his own, so we've given him an overall damage resistance decrease.

We made him twice as weak to direct damage, and balanced the grenade- and explosive damage so he feels like an upgraded version of a Brute Warlord, taking 5 M41 SPNKr rockets to kill.

The most effective way to now kill Tremonius is by using explosive plasma damage. One can now effectively kill Tremonius with:
- Fuel Rod SPNKr: 6 shots
- [38] Infiltrator Off Worlds: 10 shots
- M41 SPNKr: 5 shots
- Plasma Grenade: 4 grenades
- Wraith: 2 shots
- Banshee: 6 bombs

## Boss Harbinger overall damage resistance decrease

(Lower values on direct damage and higher values on grenade- and explosive scalars mean less resistance)
Fighting the Boss Harbinger in playtests felt too drawn-out and annoying as it took a long time for players to damage the AI in the first place as they were teleporting all over the place.

We've removed all damage resistance from the Harbinger, which now results in the AI dying faster, leading to less frustration. We will continue to monitor feedback around how this boss feels, as it's a very unique and difficult to balance experience compared to the other bosses.