### PR TITLE
Spike gun rename and Forklift Warrior sprint return

### DIFF
--- a/docs/items/weapon-configs.md
+++ b/docs/items/weapon-configs.md
@@ -543,7 +543,6 @@ The configurations that make up each of the custom weapons.
     - Empty Reload Scalar: 3.00
     - Tactical Reload Scalar: 3.00
   - Jump Height: 1.25
-  - Sprint Enabled: FALSE
 - Config: Combo
 - Ammo Adjustment: 100
   - 36+216

--- a/docs/items/weapon-configs.md
+++ b/docs/items/weapon-configs.md
@@ -458,8 +458,8 @@ The configurations that make up each of the custom weapons.
 - Game State: 5
 - Notes: Makes audible noise that alerts the enemy team to a wielder's presence in close range.
 
-## [37] Spike Off Ordo 'Mal
-- Weapon Type: MLRS-2 Hydra + S7 Flexfire Sniper
+## [37] Spike Off Thav 'Sebarim
+- Weapon Type: Cindershot + S7 Flexfire Sniper
 - Trait Set: 37
   - Weapon Damage: 0.01
 - Config: Projectile

--- a/docs/npc/ai-variants-custom.md
+++ b/docs/npc/ai-variants-custom.md
@@ -5,245 +5,245 @@ Documentation of all the custom AI variants used for the Warzone mode. Only the 
 <!--
 ## [#] AI Name
 ![AI preview](../../assets/ai-01.jpg)
-* Primary Weapon Type: #
-* Secondary Weapon Type: #
-* Grenade Type: # Grenade
-* Trait Set: ?
-  * Weapon Damage: #.##
-  * Damage Resistance
-    * Direct Damage Scalar: #.##
-    * Grenade Damage Scalar: #.##
-    * Explosive Damage Scalar: #.##
-* Notes: -
+- Primary Weapon Type: #
+- Secondary Weapon Type: #
+- Grenade Type: # Grenade
+- Trait Set: ?
+  - Weapon Damage: #.##
+  - Damage Resistance
+    - Direct Damage Scalar: #.##
+    - Grenade Damage Scalar: #.##
+    - Explosive Damage Scalar: #.##
+- Notes: -
 -->
 
 ## [1] Grunt Conscript, Yellow
 
 ![AI preview](../../assets/ai-04.jpg)
-* Primary Weapon Type: Mk50 Sidekick
-* Trait Set: -
-* Notes: -
+- Primary Weapon Type: Mk50 Sidekick
+- Trait Set: -
+- Notes: -
 
 ## [2] Grunt Ultra
 
 ![AI preview](../../assets/ai-05.jpg)
-* Primary Weapon Type: Mangler + Arcane Sentinel Beam
-* Trait Set: ?
-  * Weapon Damage: Same as [[38] Infiltrator Off Worlds](../items/weapon-configs.md#38-infiltrator-off-worlds) including projectile-related values
-  * Damage Resistance
-    * Direct Damage Scalar: 3.80
-    * Grenade Damage Scalar: 0.83
-    * Explosive Damage Scalar: 0.83
-* Notes: Will die in 4 Hydra direct rockets and 2 Rocket Launcher Rockets. Drops a [[38] Infiltrator Off Worlds](../items/weapon-configs.md#38-infiltrator-off-worlds) upon death and deletes the Mangler + Arcane Sentinel Beam.
+- Primary Weapon Type: Mangler + Arcane Sentinel Beam
+- Trait Set: ?
+  - Weapon Damage: Same as [[38] Infiltrator Off Worlds](../items/weapon-configs.md#38-infiltrator-off-worlds) including projectile-related values
+  - Damage Resistance
+    - Direct Damage Scalar: 3.80
+    - Grenade Damage Scalar: 0.83
+    - Explosive Damage Scalar: 0.83
+- Notes: Will die in 4 Hydra direct rockets and 2 Rocket Launcher Rockets. Drops a [[38] Infiltrator Off Worlds](../items/weapon-configs.md#38-infiltrator-off-worlds) upon death and deletes the Mangler + Arcane Sentinel Beam.
 
 ## [3] Boss Bipbap
 
 ![AI preview](../../assets/ai-06.jpg)
-* Primary Weapon Type: Disruptor
-* Trait Set: -
-* Notes: Is a Boss and has a health bar.
+- Primary Weapon Type: Disruptor
+- Trait Set: -
+- Notes: Is a Boss and has a health bar.
 
 ## [4] Jackal Freebooter
 
 ![AI preview](../../assets/ai-08.jpg)
-* Trait Set: -
-* Notes: -
+- Trait Set: -
+- Notes: -
 
 ## [5] Jackal Raider
 
 ![AI preview](../../assets/ai-09.jpg)
-* Trait Set: -
-* Notes: -
+- Trait Set: -
+- Notes: -
 
 ## [6] Jackal Sniper
 
 ![AI preview](../../assets/ai-11.jpg)
-* Trait Set: ?
-  * Weapon Damage: 1.30
-* Notes: -
+- Trait Set: ?
+  - Weapon Damage: 1.30
+- Notes: -
 
 ## [7] Marine Assault
 
 ![AI preview](../../assets/ai-18.jpg)
-* Trait Set: ?
-  * Weapon Damage: 3.50
-  * Damage Resistance
-    * Direct Damage Scalar: 0.30
-    * Grenade Damage Scalar: 3.3333
-    * Explosive Damage Scalar: 3.3333
-* Notes: -
+- Trait Set: ?
+  - Weapon Damage: 3.50
+  - Damage Resistance
+    - Direct Damage Scalar: 0.30
+    - Grenade Damage Scalar: 3.3333
+    - Explosive Damage Scalar: 3.3333
+- Notes: -
 
 ## [8] Elite Mercenary
 
 ![AI preview](../../assets/ai-25.jpg)
-* Trait Set: ?
-  * Damage Resistance
-    * Direct Damage Scalar: 1.20
-    * Grenade Damage Scalar: 1.69
-    * Explosive Damage Scalar: 1.69
-* Notes: Will die in 3 Hydra direct rockets and 1 Rocket Launcher Rocket
+- Trait Set: ?
+  - Damage Resistance
+    - Direct Damage Scalar: 1.20
+    - Grenade Damage Scalar: 1.69
+    - Explosive Damage Scalar: 1.69
+- Notes: Will die in 3 Hydra direct rockets and 1 Rocket Launcher Rocket
 
 ## [9] Elite Warlord
 
 ![AI preview](../../assets/ai-27.jpg)
-* Primary Weapon Type: Stalker Rifle
-* Secondary Weapon Type: None
-* Trait Set: -
-  * Damage Resistance
-    * Direct Damage Scalar: 2.00
-    * Grenade Damage Scalar: 1.30
-    * Explosive Damage Scalar: 1.30
-* Notes: Will die in 4 direct M41 SPNKr rockets.
+- Primary Weapon Type: Stalker Rifle
+- Secondary Weapon Type: None
+- Trait Set: -
+  - Damage Resistance
+    - Direct Damage Scalar: 2.00
+    - Grenade Damage Scalar: 1.30
+    - Explosive Damage Scalar: 1.30
+- Notes: Will die in 4 direct M41 SPNKr rockets.
 
 ## [10] Elite Ultra
 
 ![AI preview](../../assets/ai-28.jpg)
-* Primary Weapon Type: Rapidfire Pulse Carbine
-* Trait Set: -
-  * Damage Resistance
-    * Direct Damage Scalar: 1.00
-    * Grenade Damage Scalar: 1.84
-    * Explosive Damage Scalar: 1.84
-* Notes: Will die in 4 Hydra direct rockets and 2 Rocket Launcher Rockets. Drives a Ghost in [[8] Hunter Encounter, Mythic](../items/../npc/encounter-configs.md#8-hunter-encounter-mythic)
+- Primary Weapon Type: Rapidfire Pulse Carbine
+- Trait Set: -
+  - Damage Resistance
+    - Direct Damage Scalar: 1.00
+    - Grenade Damage Scalar: 1.84
+    - Explosive Damage Scalar: 1.84
+- Notes: Will die in 4 Hydra direct rockets and 2 Rocket Launcher Rockets. Drives a Ghost in [[8] Hunter Encounter, Mythic](../items/../npc/encounter-configs.md#8-hunter-encounter-mythic)
 
 ## [11] Boss Ordo 'Mal
 
 ![AI preview](../../assets/ai-31.jpg)
-* Primary Weapon Type: Heatwave
-* Secondary Weapon Type: None
-* Trait Set: -
-* Notes: Is a Boss and has a health bar.
+- Primary Weapon Type: Heatwave
+- Secondary Weapon Type: None
+- Trait Set: -
+- Notes: Is a Boss and has a health bar.
 
 ## [12] Boss Thav 'Sebarim
 
 ![AI preview](../../assets/ai-33.jpg)
-* Primary Weapon Type: Same as [[37] Spike Off Ordo 'Mal](https://github.com/The-Scripters-Guild/Warzone/blob/main/docs/items/weapon-configs.md#37-spike-off-ordo-mal) including projectile-related values.
-* Trait Set: ?
-  * Weapon Damage: 1.30
-  * Damage Resistance
-    * Direct Damage Scalar: 1.30
-    * Grenade Damage Scalar: 0.7692
-    * Explosive Damage Scalar: 0.7692
-* Notes: Is a Boss and has a health bar. Drops a [[37] Spike Off Ordo 'Mal](https://github.com/The-Scripters-Guild/Warzone/blob/main/docs/items/weapon-configs.md#37-spike-off-ordo-mal) upon death and deletes the Cindershot + Arcane Sentinel Beam.
+- Primary Weapon Type: Same as [[37] Spike Off Ordo 'Mal](https://github.com/The-Scripters-Guild/Warzone/blob/main/docs/items/weapon-configs.md#37-spike-off-ordo-mal) including projectile-related values.
+- Trait Set: ?
+  - Weapon Damage: 1.30
+  - Damage Resistance
+    - Direct Damage Scalar: 1.30
+    - Grenade Damage Scalar: 0.7692
+    - Explosive Damage Scalar: 0.7692
+- Notes: Is a Boss and has a health bar. Drops a [[37] Spike Off Ordo 'Mal](https://github.com/The-Scripters-Guild/Warzone/blob/main/docs/items/weapon-configs.md#37-spike-off-ordo-mal) upon death and deletes the Cindershot + Arcane Sentinel Beam.
 
 ## [13] Hunter
 
 ![AI preview](../../assets/ai-35.jpg)
-* Trait Set: ?
-  * Weapon Damage: 0.70
-  * Damage Resistance
-    * Direct Damage Scalar: 0.40
-    * Grenade Damage Scalar: 4.00
-    * Explosive Damage Scalar: 0.70
-* Notes: Is a Boss and has a health bar. 2 direct M41 SPNkrs in the front or 1 in the back will kill. 2 well-placed Frag Grenades will kill.
+- Trait Set: ?
+  - Weapon Damage: 0.70
+  - Damage Resistance
+    - Direct Damage Scalar: 0.40
+    - Grenade Damage Scalar: 4.00
+    - Explosive Damage Scalar: 0.70
+- Notes: Is a Boss and has a health bar. 2 direct M41 SPNkrs in the front or 1 in the back will kill. 2 well-placed Frag Grenades will kill.
 
 ## [14] Boss Myriad
 
 ![AI preview](../../assets/ai-37.jpg)
-* Trait Set: ?
-  * Weapon Damage: 1.30
-  * Damage Resistance
-    * Direct Damage Scalar: 2.00
-    * Grenade Damage Scalar: 0.50
-    * Explosive Damage Scalar: 0.50
-* Notes: Is a Boss and has a health bar.
+- Trait Set: ?
+  - Weapon Damage: 1.30
+  - Damage Resistance
+    - Direct Damage Scalar: 2.00
+    - Grenade Damage Scalar: 0.50
+    - Explosive Damage Scalar: 0.50
+- Notes: Is a Boss and has a health bar.
 
 ## [15] Brute Minor
 
 ![AI preview](../../assets/ai-38.jpg)
-* Primary Weapon Type: MA40 Longshot
-* Secondary Weapon Type: None
-* Trait Set: ?
-  * Damage Resistance
-    * Direct Damage Scalar: 4.30
-    * Grenade Damage Scalar: 2.57
-    * Explosive Damage Scalar: 2.57
-* Notes: Will die in 3 Hydra direct rockets and 1 Rocket Launcher Rocket.
+- Primary Weapon Type: MA40 Longshot
+- Secondary Weapon Type: None
+- Trait Set: ?
+  - Damage Resistance
+    - Direct Damage Scalar: 4.30
+    - Grenade Damage Scalar: 2.57
+    - Explosive Damage Scalar: 2.57
+- Notes: Will die in 3 Hydra direct rockets and 1 Rocket Launcher Rocket.
 
 ## [16] Brute Berserker, Chosen
 
 ![AI preview](../../assets/ai-40.jpg)
-* Primary Weapon Type: CQS48 Bulldog + Diminisher of Hope
-* Trait Set: ?
-  * Weapon Damage: Same as [[12] Valor Off Dinh](../items/weapon-configs.md#12-valor-off-dinh)
-  * Damage Resistance
-    * Direct Damage Scalar: 4.30
-    * Grenade Damage Scalar: 0.2325
-    * Explosive Damage Scalar: 0.2325
-* Notes: Is a Boss and has a health bar.
+- Primary Weapon Type: CQS48 Bulldog + Diminisher of Hope
+- Trait Set: ?
+  - Weapon Damage: Same as [[12] Valor Off Dinh](../items/weapon-configs.md#12-valor-off-dinh)
+  - Damage Resistance
+    - Direct Damage Scalar: 4.30
+    - Grenade Damage Scalar: 0.2325
+    - Explosive Damage Scalar: 0.2325
+- Notes: Is a Boss and has a health bar.
 
 ## [17] Brute Warrior
 
 ![AI preview](../../assets/ai-43.jpg)
-* Primary Weapon Type: VK78 Commando Rifle
-* Trait Set: ?
-  * Damage Resistance
-    * Direct Damage Scalar: 4.30
-    * Grenade Damage Scalar: 2.57
-    * Explosive Damage Scalar: 2.57
-* Notes: Will die in 4 Hydra direct rockets and 2 Rocket Launcher Rockets. Drives a Wraith in [[6] Brute 1 Encounter, Legendary](../items/../npc/encounter-configs.md#6-brute-1-encounter-legendary)
+- Primary Weapon Type: VK78 Commando Rifle
+- Trait Set: ?
+  - Damage Resistance
+    - Direct Damage Scalar: 4.30
+    - Grenade Damage Scalar: 2.57
+    - Explosive Damage Scalar: 2.57
+- Notes: Will die in 4 Hydra direct rockets and 2 Rocket Launcher Rockets. Drives a Wraith in [[6] Brute 1 Encounter, Legendary](../items/../npc/encounter-configs.md#6-brute-1-encounter-legendary)
 
 ## [18] Brute Sniper, Heavy
 
 ![AI preview](../../assets/ai-46.jpg)
-* Trait Set: ?
-  * Damage Resistance
-    * Direct Damage Scalar: 10.00
-    * Grenade Damage Scalar: 1.40
-    * Explosive Damage Scalar: 1.40
-* Notes: Will die in 4 direct M41 SPNKr rockets.
+- Trait Set: ?
+  - Damage Resistance
+    - Direct Damage Scalar: 10.00
+    - Grenade Damage Scalar: 1.40
+    - Explosive Damage Scalar: 1.40
+- Notes: Will die in 4 direct M41 SPNKr rockets.
 
 ## [19] Brute Warlord
 
 ![AI preview](../../assets/ai-47.jpg)
-* Primary Weapon Type: Ravager Rebound
-* Trait Set: ?
-  * Damage Resistance
-    * Direct Damage Scalar: 3.80
-    * Grenade Damage Scalar: 2.10
-    * Explosive Damage Scalar: 2.10
-* Notes: Will die in 4 direct M41 SPNKr rockets.
+- Primary Weapon Type: Ravager Rebound
+- Trait Set: ?
+  - Damage Resistance
+    - Direct Damage Scalar: 3.80
+    - Grenade Damage Scalar: 2.10
+    - Explosive Damage Scalar: 2.10
+- Notes: Will die in 4 direct M41 SPNKr rockets.
 
 ## [20] Brute Chieftain
 
 ![AI preview](../../assets/ai-50.jpg)
-* Primary Weapon Type: None
-* Trait Set: ?
-  * Damage Resistance
-    * Direct Damage Scalar: 0.60
-    * Grenade Damage Scalar: 1.6666
-    * Explosive Damage Scalar: 1.6666
-* Notes: Has no weapon, but the vehicle EMP effect from the melee still stays. This AI is used to punish players who try to splatter the encounter's boss with a vehicle.
+- Primary Weapon Type: None
+- Trait Set: ?
+  - Damage Resistance
+    - Direct Damage Scalar: 0.60
+    - Grenade Damage Scalar: 1.6666
+    - Explosive Damage Scalar: 1.6666
+- Notes: Has no weapon, but the vehicle EMP effect from the melee still stays. This AI is used to punish players who try to splatter the encounter's boss with a vehicle.
 
 ## [21] Boss Arthoc
 
 ![AI preview](../../assets/ai-54.jpg)
-* Primary Weapon Type: Ravager
-* Trait Set: -
-* Notes: Is a Boss and has a health bar.
+- Primary Weapon Type: Ravager
+- Trait Set: -
+- Notes: Is a Boss and has a health bar.
 
 ## [22] Boss Tremonius
 
 ![AI preview](../../assets/ai-62.jpg)
-* Primary Weapon Type: Pursuit Hydra
-* Trait Set: ?
-  * Damage Resistance
-    * Direct Damage Scalar: 1.00
-    * Grenade Damage Scalar: 1.50
-    * Explosive Damage Scalar: 1.50
-* Notes: Is a Boss and has a health bar. Weak to explosive plasma damage.
+- Primary Weapon Type: Pursuit Hydra
+- Trait Set: ?
+  - Damage Resistance
+    - Direct Damage Scalar: 1.00
+    - Grenade Damage Scalar: 1.50
+    - Explosive Damage Scalar: 1.50
+- Notes: Is a Boss and has a health bar. Weak to explosive plasma damage.
 
 ## [23] Boss Escharum
 
 ![AI preview](../../assets/ai-63.jpg)
-* Trait Set: -
-* Notes: Is a Boss and has a health bar.
+- Trait Set: -
+- Notes: Is a Boss and has a health bar.
 
 ## [24] Boss Harbinger
 
 ![AI preview](../../assets/ai-66.jpg)
-* Trait Set: -
-* Notes: Is a Boss and has a health bar. Has four stages of dealing damage to their shield, and then their health, before dying.
+- Trait Set: -
+- Notes: Is a Boss and has a health bar. Has four stages of dealing damage to their shield, and then their health, before dying.
 
 ## Acknowledgements
 

--- a/docs/npc/ai-variants-default.md
+++ b/docs/npc/ai-variants-default.md
@@ -5,1278 +5,1278 @@ Documentation of all the default AI variants.
 <!--
 ## [#] AI Name
 ![AI preview](../../assets/ai-01.jpg)
-* Primary Weapon Type: #
-* Secondary Weapon Type: #
-* Grenade Type: # Grenade
-* Health per difficulty
-  * Easy: #
-  * Normal: #
-  * Heroic: #
-  * Legendary: #
-* Shield per difficulty
-  * Easy: #
-  * Normal: #
-  * Heroic: #
-  * Legendary: #
-* Species: #
-* Notes: -
+- Primary Weapon Type: #
+- Secondary Weapon Type: #
+- Grenade Type: # Grenade
+- Health per difficulty
+  - Easy: #
+  - Normal: #
+  - Heroic: #
+  - Legendary: #
+- Shield per difficulty
+  - Easy: #
+  - Normal: #
+  - Heroic: #
+  - Legendary: #
+- Species: #
+- Notes: -
 -->
 
 ## [1] Grunt Assault, Purple
 
 ![AI preview](../../assets/ai-01.jpg)
-* Primary Weapon Type: Needler
-* Secondary Weapon Type: -
-* Grenade Type: Plasma Grenade
-* Health per difficulty
-  * Easy: 105
-  * Normal: 105
-  * Heroic: 132.5
-  * Legendary: 160
-* Shield per difficulty
-  * Easy: 0
-  * Normal: 0
-  * Heroic: 0
-  * Legendary: 0
-* Species: Grunt
-* Notes: -
+- Primary Weapon Type: Needler
+- Secondary Weapon Type: -
+- Grenade Type: Plasma Grenade
+- Health per difficulty
+  - Easy: 105
+  - Normal: 105
+  - Heroic: 132.5
+  - Legendary: 160
+- Shield per difficulty
+  - Easy: 0
+  - Normal: 0
+  - Heroic: 0
+  - Legendary: 0
+- Species: Grunt
+- Notes: -
 
 ## [2] Grunt Assault, Red
 
 ![AI preview](../../assets/ai-02.jpg)
-* Primary Weapon Type: Plasma Pistol
-* Secondary Weapon Type: -
-* Grenade Type: Plasma Grenade
-* Health per difficulty
-  * Easy: 105
-  * Normal: 105
-  * Heroic: 132.5
-  * Legendary: 160
-* Shield per difficulty
-  * Easy: 0
-  * Normal: 0
-  * Heroic: 0
-  * Legendary: 0
-* Species: Grunt
-* Notes: -
+- Primary Weapon Type: Plasma Pistol
+- Secondary Weapon Type: -
+- Grenade Type: Plasma Grenade
+- Health per difficulty
+  - Easy: 105
+  - Normal: 105
+  - Heroic: 132.5
+  - Legendary: 160
+- Shield per difficulty
+  - Easy: 0
+  - Normal: 0
+  - Heroic: 0
+  - Legendary: 0
+- Species: Grunt
+- Notes: -
 
 ## [3] Grunt Conscript, Blue
 
 ![AI preview](../../assets/ai-03.jpg)
-* Primary Weapon Type: Needler
-* Secondary Weapon Type: -
-* Grenade Type: Plasma Grenade
-* Health per difficulty
-  * Easy: 60
-  * Normal: 60
-  * Heroic: 80
-  * Legendary: 100
-* Shield per difficulty
-  * Easy: 0
-  * Normal: 0
-  * Heroic: 0
-  * Legendary: 0
-* Species: Grunt
-* Notes: -
+- Primary Weapon Type: Needler
+- Secondary Weapon Type: -
+- Grenade Type: Plasma Grenade
+- Health per difficulty
+  - Easy: 60
+  - Normal: 60
+  - Heroic: 80
+  - Legendary: 100
+- Shield per difficulty
+  - Easy: 0
+  - Normal: 0
+  - Heroic: 0
+  - Legendary: 0
+- Species: Grunt
+- Notes: -
 
 ## [4] Grunt Conscript, Yellow
 
 ![AI preview](../../assets/ai-04.jpg)
-* Primary Weapon Type: Plasma Pistol
-* Secondary Weapon Type: -
-* Grenade Type: Plasma Grenade
-* Health per difficulty
-  * Easy: 60
-  * Normal: 60
-  * Heroic: 80
-  * Legendary: 100
-* Shield per difficulty
-  * Easy: 0
-  * Normal: 0
-  * Heroic: 0
-  * Legendary: 0
-* Species: Grunt
-* Notes: -
+- Primary Weapon Type: Plasma Pistol
+- Secondary Weapon Type: -
+- Grenade Type: Plasma Grenade
+- Health per difficulty
+  - Easy: 60
+  - Normal: 60
+  - Heroic: 80
+  - Legendary: 100
+- Shield per difficulty
+  - Easy: 0
+  - Normal: 0
+  - Heroic: 0
+  - Legendary: 0
+- Species: Grunt
+- Notes: -
 
 ## [5] Grunt Ultra
 
 ![AI preview](../../assets/ai-05.jpg)
-* Primary Weapon Type: Disruptor
-* Secondary Weapon Type: -
-* Grenade Type: Plasma Grenade
-* Health per difficulty
-  * Easy: 135
-  * Normal: 135
-  * Heroic: 165
-  * Legendary: 195
-* Shield per difficulty
-  * Easy: 0
-  * Normal: 0
-  * Heroic: 0
-  * Legendary: 0
-* Species: Grunt
-* Notes: -
+- Primary Weapon Type: Disruptor
+- Secondary Weapon Type: -
+- Grenade Type: Plasma Grenade
+- Health per difficulty
+  - Easy: 135
+  - Normal: 135
+  - Heroic: 165
+  - Legendary: 195
+- Shield per difficulty
+  - Easy: 0
+  - Normal: 0
+  - Heroic: 0
+  - Legendary: 0
+- Species: Grunt
+- Notes: -
 
 ## [6] Boss Bipbap
 
 ![AI preview](../../assets/ai-06.jpg)
-* Primary Weapon Type: Calcine Disruptor
-* Secondary Weapon Type: -
-* Grenade Type: Plasma Grenade
-* Health per difficulty
-  * Easy: 135
-  * Normal: 135
-  * Heroic: 165
-  * Legendary: 195
-* Shield per difficulty
-  * Easy: 500
-  * Normal: 500
-  * Heroic: 650
-  * Legendary: 800
-* Species: Grunt
-* Notes: Only Grunt with a shield value.
+- Primary Weapon Type: Calcine Disruptor
+- Secondary Weapon Type: -
+- Grenade Type: Plasma Grenade
+- Health per difficulty
+  - Easy: 135
+  - Normal: 135
+  - Heroic: 165
+  - Legendary: 195
+- Shield per difficulty
+  - Easy: 500
+  - Normal: 500
+  - Heroic: 650
+  - Legendary: 800
+- Species: Grunt
+- Notes: Only Grunt with a shield value.
 
 ## [7] Boss Briglard
 
 ![AI preview](../../assets/ai-07.jpg)
-* Primary Weapon Type: Unbound Plasma Pistol
-* Secondary Weapon Type: -
-* Grenade Type: Plasma Grenade
-* Health per difficulty
-  * Easy: 175
-  * Normal: 175
-  * Heroic: 210
-  * Legendary: 245
-* Shield per difficulty
-  * Easy: 0
-  * Normal: 0
-  * Heroic: 0
-  * Legendary: 0
-* Species: Grunt
-* Notes: Has a Ravager, CQS48 Bulldog and Shock Rifle on its back that can be picked up even when the AI is alive.
+- Primary Weapon Type: Unbound Plasma Pistol
+- Secondary Weapon Type: -
+- Grenade Type: Plasma Grenade
+- Health per difficulty
+  - Easy: 175
+  - Normal: 175
+  - Heroic: 210
+  - Legendary: 245
+- Shield per difficulty
+  - Easy: 0
+  - Normal: 0
+  - Heroic: 0
+  - Legendary: 0
+- Species: Grunt
+- Notes: Has a Ravager, CQS48 Bulldog and Shock Rifle on its back that can be picked up even when the AI is alive.
 
 ## [8] Jackal Freebooter
 
 ![AI preview](../../assets/ai-08.jpg)
-* Primary Weapon Type: Plasma Pistol
-* Secondary Weapon Type: -
-* Grenade Type: -
-* Health per difficulty
-  * Easy: 100
-  * Normal: 100
-  * Heroic: 120
-  * Legendary: 140
-* Shield per difficulty
-  * Easy: 0
-  * Normal: 0
-  * Heroic: 0
-  * Legendary: 0
-* Species: Jackal
-* Notes: Has a blue shield object in one hand that is separate from the AI health and shield values.
+- Primary Weapon Type: Plasma Pistol
+- Secondary Weapon Type: -
+- Grenade Type: -
+- Health per difficulty
+  - Easy: 100
+  - Normal: 100
+  - Heroic: 120
+  - Legendary: 140
+- Shield per difficulty
+  - Easy: 0
+  - Normal: 0
+  - Heroic: 0
+  - Legendary: 0
+- Species: Jackal
+- Notes: Has a blue shield object in one hand that is separate from the AI health and shield values.
 
 ## [9] Jackal Raider
 
 ![AI preview](../../assets/ai-09.jpg)
-* Primary Weapon Type: Needler
-* Secondary Weapon Type: -
-* Grenade Type: -
-* Health per difficulty
-  * Easy: 140
-  * Normal: 140
-  * Heroic: 175
-  * Legendary: 210
-* Shield per difficulty
-  * Easy: 0
-  * Normal: 0
-  * Heroic: 0
-  * Legendary: 0
-* Species: Jackal
-* Notes: Has a yellow shield object in one hand that is separate from the AI health and shield values and can absorb bullets.
+- Primary Weapon Type: Needler
+- Secondary Weapon Type: -
+- Grenade Type: -
+- Health per difficulty
+  - Easy: 140
+  - Normal: 140
+  - Heroic: 175
+  - Legendary: 210
+- Shield per difficulty
+  - Easy: 0
+  - Normal: 0
+  - Heroic: 0
+  - Legendary: 0
+- Species: Jackal
+- Notes: Has a yellow shield object in one hand that is separate from the AI health and shield values and can absorb bullets.
 
 ## [10] Jackal Skirmisher
 
 ![AI preview](../../assets/ai-10.jpg)
-* Primary Weapon Type: Needler
-* Secondary Weapon Type: -
-* Grenade Type: -
-* Health per difficulty
-  * Easy: 160
-  * Normal: 160
-  * Heroic: 220
-  * Legendary: 280
-* Shield per difficulty
-  * Easy: 0
-  * Normal: 0
-  * Heroic: 0
-  * Legendary: 0
-* Species: Jackal
-* Notes: Has blue shields on its arms that are separate from the AI health and shield values and can absorb bullets.
+- Primary Weapon Type: Needler
+- Secondary Weapon Type: -
+- Grenade Type: -
+- Health per difficulty
+  - Easy: 160
+  - Normal: 160
+  - Heroic: 220
+  - Legendary: 280
+- Shield per difficulty
+  - Easy: 0
+  - Normal: 0
+  - Heroic: 0
+  - Legendary: 0
+- Species: Jackal
+- Notes: Has blue shields on its arms that are separate from the AI health and shield values and can absorb bullets.
 
 ## [11] Jackal Sniper
 
 ![AI preview](../../assets/ai-11.jpg)
-* Primary Weapon Type: Stalker Rifle
-* Secondary Weapon Type: -
-* Grenade Type: -
-* Health per difficulty
-  * Easy: 60
-  * Normal: 60
-  * Heroic: 75
-  * Legendary: 90
-* Shield per difficulty
-  * Easy: 0
-  * Normal: 0
-  * Heroic: 0
-  * Legendary: 0
-* Species: Jackal
-* Notes: -
+- Primary Weapon Type: Stalker Rifle
+- Secondary Weapon Type: -
+- Grenade Type: -
+- Health per difficulty
+  - Easy: 60
+  - Normal: 60
+  - Heroic: 75
+  - Legendary: 90
+- Shield per difficulty
+  - Easy: 0
+  - Normal: 0
+  - Heroic: 0
+  - Legendary: 0
+- Species: Jackal
+- Notes: -
 
 ## [12] Boss Barroth
 
 ![AI preview](../../assets/ai-12.jpg)
-* Primary Weapon Type: Stalker Rifle Ultra
-* Secondary Weapon Type: -
-* Grenade Type: -
-* Health per difficulty
-  * Easy: 250
-  * Normal: 250
-  * Heroic: 300
-  * Legendary: 350
-* Shield per difficulty
-  * Easy: 0
-  * Normal: 0
-  * Heroic: 0
-  * Legendary: 0
-* Species: Jackal
-* Notes: -
+- Primary Weapon Type: Stalker Rifle Ultra
+- Secondary Weapon Type: -
+- Grenade Type: -
+- Health per difficulty
+  - Easy: 250
+  - Normal: 250
+  - Heroic: 300
+  - Legendary: 350
+- Shield per difficulty
+  - Easy: 0
+  - Normal: 0
+  - Heroic: 0
+  - Legendary: 0
+- Species: Jackal
+- Notes: -
 
 ## [13] Boss Writh Kul
 
 ![AI preview](../../assets/ai-13.jpg)
-* Primary Weapon Type: Pinpoint Needler
-* Secondary Weapon Type: -
-* Grenade Type: -
-* Health per difficulty
-  * Easy: 450
-  * Normal: 450
-  * Heroic: 525
-  * Legendary: 600
-* Shield per difficulty
-  * Easy: 0
-  * Normal: 0
-  * Heroic: 0
-  * Legendary: 0
-* Species: Jackal
-* Notes: Has blue shields on its arms that are separate from the AI health and shield values and can absorb bullets.
+- Primary Weapon Type: Pinpoint Needler
+- Secondary Weapon Type: -
+- Grenade Type: -
+- Health per difficulty
+  - Easy: 450
+  - Normal: 450
+  - Heroic: 525
+  - Legendary: 600
+- Shield per difficulty
+  - Easy: 0
+  - Normal: 0
+  - Heroic: 0
+  - Legendary: 0
+- Species: Jackal
+- Notes: Has blue shields on its arms that are separate from the AI health and shield values and can absorb bullets.
 
 ## [14] Skimmer
 
 ![AI preview](../../assets/ai-14.jpg)
-* Primary Weapon Type: Shock Rifle
-* Secondary Weapon Type: -
-* Grenade Type: Dynamo Grenade
-* Health per difficulty
-  * Easy: 100
-  * Normal: 100
-  * Heroic: 150
-  * Legendary: 200
-* Shield per difficulty
-  * Easy: 0
-  * Normal: 0
-  * Heroic: 0
-  * Legendary: 0
-* Species: Skimmer
-* Notes: -
+- Primary Weapon Type: Shock Rifle
+- Secondary Weapon Type: -
+- Grenade Type: Dynamo Grenade
+- Health per difficulty
+  - Easy: 100
+  - Normal: 100
+  - Heroic: 150
+  - Legendary: 200
+- Shield per difficulty
+  - Easy: 0
+  - Normal: 0
+  - Heroic: 0
+  - Legendary: 0
+- Species: Skimmer
+- Notes: -
 
 ## [15] Skimmer Loyalist
 
 ![AI preview](../../assets/ai-15.jpg)
-* Primary Weapon Type: VK78 Commando Rifle
-* Secondary Weapon Type: -
-* Grenade Type: Dynamo Grenade
-* Health per difficulty
-  * Easy: 100
-  * Normal: 100
-  * Heroic: 150
-  * Legendary: 200
-* Shield per difficulty
-  * Easy: 0
-  * Normal: 0
-  * Heroic: 0
-  * Legendary: 0
-* Species: Skimmer
-* Notes: -
+- Primary Weapon Type: VK78 Commando Rifle
+- Secondary Weapon Type: -
+- Grenade Type: Dynamo Grenade
+- Health per difficulty
+  - Easy: 100
+  - Normal: 100
+  - Heroic: 150
+  - Legendary: 200
+- Shield per difficulty
+  - Easy: 0
+  - Normal: 0
+  - Heroic: 0
+  - Legendary: 0
+- Species: Skimmer
+- Notes: -
 
 ## [16] Skimmer Ultra
 
 ![AI preview](../../assets/ai-16.jpg)
-* Primary Weapon Type: M41 SPNKr
-* Secondary Weapon Type: -
-* Grenade Type: Dynamo Grenade
-* Health per difficulty
-  * Easy: 100
-  * Normal: 100
-  * Heroic: 150
-  * Legendary: 200
-* Shield per difficulty
-  * Easy: 0
-  * Normal: 0
-  * Heroic: 0
-  * Legendary: 0
-* Species: Skimmer
-* Notes: -
+- Primary Weapon Type: M41 SPNKr
+- Secondary Weapon Type: -
+- Grenade Type: Dynamo Grenade
+- Health per difficulty
+  - Easy: 100
+  - Normal: 100
+  - Heroic: 150
+  - Legendary: 200
+- Shield per difficulty
+  - Easy: 0
+  - Normal: 0
+  - Heroic: 0
+  - Legendary: 0
+- Species: Skimmer
+- Notes: -
 
 ## [17] Boss Skimmer Alpha
 
 ![AI preview](../../assets/ai-17.jpg)
-* Primary Weapon Type: Purging Shock Rifle
-* Secondary Weapon Type: -
-* Grenade Type: Dynamo Grenade
-* Health per difficulty
-  * Easy: 350
-  * Normal: 350
-  * Heroic: 425
-  * Legendary: 500
-* Shield per difficulty
-  * Easy: 0
-  * Normal: 0
-  * Heroic: 0
-  * Legendary: 0
-* Species: Skimmer
-* Notes: -
+- Primary Weapon Type: Purging Shock Rifle
+- Secondary Weapon Type: -
+- Grenade Type: Dynamo Grenade
+- Health per difficulty
+  - Easy: 350
+  - Normal: 350
+  - Heroic: 425
+  - Legendary: 500
+- Shield per difficulty
+  - Easy: 0
+  - Normal: 0
+  - Heroic: 0
+  - Legendary: 0
+- Species: Skimmer
+- Notes: -
 
 ## [18] Marine Assault
 
 ![AI preview](../../assets/ai-18.jpg)
-* Primary Weapon Type: MA40 Assault Rifle
-* Secondary Weapon Type: -
-* Grenade Type: Frag Grenade
-* Health per difficulty
-  * Easy: 110
-  * Normal: 110
-  * Heroic: 192.5
-  * Legendary: 275
-* Shield per difficulty
-  * Easy: 0
-  * Normal: 0
-  * Heroic: 0
-  * Legendary: 0
-* Species: Human
-* Notes: -
+- Primary Weapon Type: MA40 Assault Rifle
+- Secondary Weapon Type: -
+- Grenade Type: Frag Grenade
+- Health per difficulty
+  - Easy: 110
+  - Normal: 110
+  - Heroic: 192.5
+  - Legendary: 275
+- Shield per difficulty
+  - Easy: 0
+  - Normal: 0
+  - Heroic: 0
+  - Legendary: 0
+- Species: Human
+- Notes: -
 
 ## [19] Marine Demolition
 
 ![AI preview](../../assets/ai-19.jpg)
-* Primary Weapon Type: M41 SPNKr
-* Secondary Weapon Type: CQS48 Bulldog
-* Grenade Type: Frag Grenade
-* Health per difficulty
-  * Easy: 165
-  * Normal: 165
-  * Heroic: 277.5
-  * Legendary: 412
-* Shield per difficulty
-  * Easy: 0
-  * Normal: 0
-  * Heroic: 0
-  * Legendary: 0
-* Species: Human
-* Notes: -
+- Primary Weapon Type: M41 SPNKr
+- Secondary Weapon Type: CQS48 Bulldog
+- Grenade Type: Frag Grenade
+- Health per difficulty
+  - Easy: 165
+  - Normal: 165
+  - Heroic: 277.5
+  - Legendary: 412
+- Shield per difficulty
+  - Easy: 0
+  - Normal: 0
+  - Heroic: 0
+  - Legendary: 0
+- Species: Human
+- Notes: -
 
 ## [20] Marine Heavy
 
 ![AI preview](../../assets/ai-20.jpg)
-* Primary Weapon Type: CQS48 Bulldog
-* Secondary Weapon Type: -
-* Grenade Type: Frag Grenade
-* Health per difficulty
-  * Easy: 165
-  * Normal: 165
-  * Heroic: 277.5
-  * Legendary: 412
-* Shield per difficulty
-  * Easy: 0
-  * Normal: 0
-  * Heroic: 0
-  * Legendary: 0
-* Species: Human
-* Notes: -
+- Primary Weapon Type: CQS48 Bulldog
+- Secondary Weapon Type: -
+- Grenade Type: Frag Grenade
+- Health per difficulty
+  - Easy: 165
+  - Normal: 165
+  - Heroic: 277.5
+  - Legendary: 412
+- Shield per difficulty
+  - Easy: 0
+  - Normal: 0
+  - Heroic: 0
+  - Legendary: 0
+- Species: Human
+- Notes: -
 
 ## [21] Marine Scout
 
 ![AI preview](../../assets/ai-21.jpg)
-* Primary Weapon Type: BR75
-* Secondary Weapon Type: -
-* Grenade Type: Frag Grenade
-* Health per difficulty
-  * Easy: 110
-  * Normal: 110
-  * Heroic: 192.5
-  * Legendary: 275
-* Shield per difficulty
-  * Easy: 0
-  * Normal: 0
-  * Heroic: 0
-  * Legendary: 0
-* Species: Human
-* Notes: -
+- Primary Weapon Type: BR75
+- Secondary Weapon Type: -
+- Grenade Type: Frag Grenade
+- Health per difficulty
+  - Easy: 110
+  - Normal: 110
+  - Heroic: 192.5
+  - Legendary: 275
+- Shield per difficulty
+  - Easy: 0
+  - Normal: 0
+  - Heroic: 0
+  - Legendary: 0
+- Species: Human
+- Notes: -
 
 ## [22] Marine Sniper
 
 ![AI preview](../../assets/ai-22.jpg)
-* Primary Weapon Type: S7 Sniper Rifle
-* Secondary Weapon Type: Mk50 Sidekick
-* Grenade Type: Frag Grenade
-* Health per difficulty
-  * Easy: 137
-  * Normal: 137
-  * Heroic: 240.5
-  * Legendary: 344
-* Shield per difficulty
-  * Easy: 0
-  * Normal: 0
-  * Heroic: 0
-  * Legendary: 0
-* Species: Human
-* Notes: -
+- Primary Weapon Type: S7 Sniper Rifle
+- Secondary Weapon Type: Mk50 Sidekick
+- Grenade Type: Frag Grenade
+- Health per difficulty
+  - Easy: 137
+  - Normal: 137
+  - Heroic: 240.5
+  - Legendary: 344
+- Shield per difficulty
+  - Easy: 0
+  - Normal: 0
+  - Heroic: 0
+  - Legendary: 0
+- Species: Human
+- Notes: -
 
 ## [23] Marine Survivor
 
 ![AI preview](../../assets/ai-23.jpg)
-* Primary Weapon Type: Mk50 Sidekick
-* Secondary Weapon Type: -
-* Grenade Type: Frag Grenade
-* Health per difficulty
-  * Easy: 83
-  * Normal: 83
-  * Heroic: 144.5
-  * Legendary: 206
-* Shield per difficulty
-  * Easy: 0
-  * Normal: 0
-  * Heroic: 0
-  * Legendary: 0
-* Species: Human
-* Notes: Has multiple different models.
+- Primary Weapon Type: Mk50 Sidekick
+- Secondary Weapon Type: -
+- Grenade Type: Frag Grenade
+- Health per difficulty
+  - Easy: 83
+  - Normal: 83
+  - Heroic: 144.5
+  - Legendary: 206
+- Shield per difficulty
+  - Easy: 0
+  - Normal: 0
+  - Heroic: 0
+  - Legendary: 0
+- Species: Human
+- Notes: Has multiple different models.
 
 ## [24] Elite Enforcer
 
 ![AI preview](../../assets/ai-24.jpg)
-* Primary Weapon Type: Pulse Carbine
-* Secondary Weapon Type: -
-* Grenade Type: Plasma Grenade
-* Health per difficulty
-  * Easy: 180
-  * Normal: 180
-  * Heroic: 215
-  * Legendary: 250
-* Shield per difficulty
-  * Easy: 320
-  * Normal: 320
-  * Heroic: 345
-  * Legendary: 370
-* Species: Elite
-* Notes: Activates shield only after engaging a target.
+- Primary Weapon Type: Pulse Carbine
+- Secondary Weapon Type: -
+- Grenade Type: Plasma Grenade
+- Health per difficulty
+  - Easy: 180
+  - Normal: 180
+  - Heroic: 215
+  - Legendary: 250
+- Shield per difficulty
+  - Easy: 320
+  - Normal: 320
+  - Heroic: 345
+  - Legendary: 370
+- Species: Elite
+- Notes: Activates shield only after engaging a target.
 
 ## [25] Elite Mercenary
 
 ![AI preview](../../assets/ai-25.jpg)
-* Primary Weapon Type: Pulse Carbine
-* Secondary Weapon Type: -
-* Grenade Type: Plasma Grenade
-* Health per difficulty
-  * Easy: 110
-  * Normal: 110
-  * Heroic: 145
-  * Legendary: 180
-* Shield per difficulty
-  * Easy: 160
-  * Normal: 160
-  * Heroic: 195
-  * Legendary: 230
-* Species: Elite
-* Notes: Activates shield only after engaging a target.
+- Primary Weapon Type: Pulse Carbine
+- Secondary Weapon Type: -
+- Grenade Type: Plasma Grenade
+- Health per difficulty
+  - Easy: 110
+  - Normal: 110
+  - Heroic: 145
+  - Legendary: 180
+- Shield per difficulty
+  - Easy: 160
+  - Normal: 160
+  - Heroic: 195
+  - Legendary: 230
+- Species: Elite
+- Notes: Activates shield only after engaging a target.
 
 ## [26] Elite Spec Ops
 
 ![AI preview](../../assets/ai-26.jpg)
-* Primary Weapon Type: Energy Sword
-* Secondary Weapon Type: -
-* Grenade Type: Plasma Grenade
-* Health per difficulty
-  * Easy: 180
-  * Normal: 180
-  * Heroic: 215
-  * Legendary: 250
-* Shield per difficulty
-  * Easy: 320
-  * Normal: 320
-  * Heroic: 345
-  * Legendary: 370
-* Species: Elite
-* Notes: Activates shield only after engaging a target. Has an Active Camouflage equipment that they may use during an engagement.
+- Primary Weapon Type: Energy Sword
+- Secondary Weapon Type: -
+- Grenade Type: Plasma Grenade
+- Health per difficulty
+  - Easy: 180
+  - Normal: 180
+  - Heroic: 215
+  - Legendary: 250
+- Shield per difficulty
+  - Easy: 320
+  - Normal: 320
+  - Heroic: 345
+  - Legendary: 370
+- Species: Elite
+- Notes: Activates shield only after engaging a target. Has an Active Camouflage equipment that they may use during an engagement.
 
 ## [27] Elite Warlord
 
 ![AI preview](../../assets/ai-27.jpg)
-* Primary Weapon Type: Ravager
-* Secondary Weapon Type: Energy Sword
-* Grenade Type: Plasma Grenade
-* Health per difficulty
-  * Easy: 220
-  * Normal: 220
-  * Heroic: 255
-  * Legendary: 290
-* Shield per difficulty
-  * Easy: 380
-  * Normal: 380
-  * Heroic: 315
-  * Legendary: 450
-* Species: Elite
-* Notes: Activates shield only after engaging a target. Has an Active Camouflage equipment that they may use during an engagement.
+- Primary Weapon Type: Ravager
+- Secondary Weapon Type: Energy Sword
+- Grenade Type: Plasma Grenade
+- Health per difficulty
+  - Easy: 220
+  - Normal: 220
+  - Heroic: 255
+  - Legendary: 290
+- Shield per difficulty
+  - Easy: 380
+  - Normal: 380
+  - Heroic: 315
+  - Legendary: 450
+- Species: Elite
+- Notes: Activates shield only after engaging a target. Has an Active Camouflage equipment that they may use during an engagement.
 
 ## [28] Elite Ultra
 
 ![AI preview](../../assets/ai-28.jpg)
-* Primary Weapon Type: Heatwave
-* Secondary Weapon Type: Energy Sword
-* Grenade Type: Plasma Grenade
-* Health per difficulty
-  * Easy: 220
-  * Normal: 220
-  * Heroic: 255
-  * Legendary: 290
-* Shield per difficulty
-  * Easy: 380
-  * Normal: 380
-  * Heroic: 315
-  * Legendary: 450
-* Species: Elite
-* Notes: Activates shield only after engaging a target. Has an Active Camouflage equipment that they may use during an engagement.
+- Primary Weapon Type: Heatwave
+- Secondary Weapon Type: Energy Sword
+- Grenade Type: Plasma Grenade
+- Health per difficulty
+  - Easy: 220
+  - Normal: 220
+  - Heroic: 255
+  - Legendary: 290
+- Shield per difficulty
+  - Easy: 380
+  - Normal: 380
+  - Heroic: 315
+  - Legendary: 450
+- Species: Elite
+- Notes: Activates shield only after engaging a target. Has an Active Camouflage equipment that they may use during an engagement.
 
 ## [29] Boss Chak 'Lok
 
 ![AI preview](../../assets/ai-29.jpg)
-* Primary Weapon Type: Pulse Carbine
-* Secondary Weapon Type: Energy Sword
-* Grenade Type: Plasma Grenade
-* Health per difficulty
-  * Easy: 300
-  * Normal: 300
-  * Heroic: 350
-  * Legendary: 400
-* Shield per difficulty
-  * Easy: 2500
-  * Normal: 2500
-  * Heroic: 3000
-  * Legendary: 3500
-* Species: Elite
-* Notes: Activates shield only after engaging a target. Has an Active Camouflage equipment that they may use during an engagement.
+- Primary Weapon Type: Pulse Carbine
+- Secondary Weapon Type: Energy Sword
+- Grenade Type: Plasma Grenade
+- Health per difficulty
+  - Easy: 300
+  - Normal: 300
+  - Heroic: 350
+  - Legendary: 400
+- Shield per difficulty
+  - Easy: 2500
+  - Normal: 2500
+  - Heroic: 3000
+  - Legendary: 3500
+- Species: Elite
+- Notes: Activates shield only after engaging a target. Has an Active Camouflage equipment that they may use during an engagement.
 
 ## [30] Boss Okro 'Vagaduun
 
 ![AI preview](../../assets/ai-30.jpg)
-* Primary Weapon Type: Duelist Energy Sword
-* Secondary Weapon Type: -
-* Grenade Type: Plasma Grenade
-* Health per difficulty
-  * Easy: 150
-  * Normal: 150
-  * Heroic: 200
-  * Legendary: 250
-* Shield per difficulty
-  * Easy: 500
-  * Normal: 500
-  * Heroic: 650
-  * Legendary: 800
-* Species: Elite
-* Notes: Activates shield only after engaging a target. Has an Active Camouflage equipment that they may use during an engagement.
+- Primary Weapon Type: Duelist Energy Sword
+- Secondary Weapon Type: -
+- Grenade Type: Plasma Grenade
+- Health per difficulty
+  - Easy: 150
+  - Normal: 150
+  - Heroic: 200
+  - Legendary: 250
+- Shield per difficulty
+  - Easy: 500
+  - Normal: 500
+  - Heroic: 650
+  - Legendary: 800
+- Species: Elite
+- Notes: Activates shield only after engaging a target. Has an Active Camouflage equipment that they may use during an engagement.
 
 ## [31] Boss Ordo 'Mal
 
 ![AI preview](../../assets/ai-31.jpg)
-* Primary Weapon Type: Scatterbound Heatwave
-* Secondary Weapon Type: Energy Sword
-* Grenade Type: Plasma Grenade
-* Health per difficulty
-  * Easy: 350
-  * Normal: 350
-  * Heroic: 375
-  * Legendary: 400
-* Shield per difficulty
-  * Easy: 700
-  * Normal: 700
-  * Heroic: 800
-  * Legendary: 900
-* Species: Elite
-* Notes: Activates shield only after engaging a target. Has an Active Camouflage equipment that they may use during an engagement.
+- Primary Weapon Type: Scatterbound Heatwave
+- Secondary Weapon Type: Energy Sword
+- Grenade Type: Plasma Grenade
+- Health per difficulty
+  - Easy: 350
+  - Normal: 350
+  - Heroic: 375
+  - Legendary: 400
+- Shield per difficulty
+  - Easy: 700
+  - Normal: 700
+  - Heroic: 800
+  - Legendary: 900
+- Species: Elite
+- Notes: Activates shield only after engaging a target. Has an Active Camouflage equipment that they may use during an engagement.
 
 ## [32] Boss Inka 'Saham
 
 ![AI preview](../../assets/ai-32.jpg)
-* Primary Weapon Type: Rapidfire Pulse Carbine
-* Secondary Weapon Type: Energy Sword
-* Grenade Type: Plasma Grenade
-* Health per difficulty
-  * Easy: 300
-  * Normal: 300
-  * Heroic: 325
-  * Legendary: 350
-* Shield per difficulty
-  * Easy: 650
-  * Normal: 650
-  * Heroic: 750
-  * Legendary: 850
-* Species: Elite
-* Notes: Activates shield only after engaging a target. Has an Active Camouflage equipment that they may use during an engagement.
+- Primary Weapon Type: Rapidfire Pulse Carbine
+- Secondary Weapon Type: Energy Sword
+- Grenade Type: Plasma Grenade
+- Health per difficulty
+  - Easy: 300
+  - Normal: 300
+  - Heroic: 325
+  - Legendary: 350
+- Shield per difficulty
+  - Easy: 650
+  - Normal: 650
+  - Heroic: 750
+  - Legendary: 850
+- Species: Elite
+- Notes: Activates shield only after engaging a target. Has an Active Camouflage equipment that they may use during an engagement.
 
 ## [33] Boss Thav 'Sebarim
 
 ![AI preview](../../assets/ai-33.jpg)
-* Primary Weapon Type: Arcane Sentinel Beam
-* Secondary Weapon Type: -
-* Grenade Type: Plasma Grenade
-* Health per difficulty
-  * Easy: 350
-  * Normal: 350
-  * Heroic: 375
-  * Legendary: 400
-* Shield per difficulty
-  * Easy: 800
-  * Normal: 800
-  * Heroic: 900
-  * Legendary: 1000
-* Species: Elite
-* Notes: Activates shield only after engaging a target. Has an Active Camouflage equipment that they may use during an engagement.
+- Primary Weapon Type: Arcane Sentinel Beam
+- Secondary Weapon Type: -
+- Grenade Type: Plasma Grenade
+- Health per difficulty
+  - Easy: 350
+  - Normal: 350
+  - Heroic: 375
+  - Legendary: 400
+- Shield per difficulty
+  - Easy: 800
+  - Normal: 800
+  - Heroic: 900
+  - Legendary: 1000
+- Species: Elite
+- Notes: Activates shield only after engaging a target. Has an Active Camouflage equipment that they may use during an engagement.
 
 ## [34] Boss Jega 'Rdomnai
 
 ![AI preview](../../assets/ai-34.jpg)
-* Primary Weapon Type: Elite Bloodblade
-* Secondary Weapon Type: -
-* Grenade Type: Plasma Grenade
-* Health per difficulty
-  * Easy: 300
-  * Normal: 300
-  * Heroic: 350
-  * Legendary: 400
-* Shield per difficulty
-  * Easy: 1400
-  * Normal: 1400
-  * Heroic: 1700
-  * Legendary: 2000
-* Species: Elite
-* Notes: Activates shield only after engaging a target. Has an Active Camouflage equipment that they may use during an engagement.
+- Primary Weapon Type: Elite Bloodblade
+- Secondary Weapon Type: -
+- Grenade Type: Plasma Grenade
+- Health per difficulty
+  - Easy: 300
+  - Normal: 300
+  - Heroic: 350
+  - Legendary: 400
+- Shield per difficulty
+  - Easy: 1400
+  - Normal: 1400
+  - Heroic: 1700
+  - Legendary: 2000
+- Species: Elite
+- Notes: Activates shield only after engaging a target. Has an Active Camouflage equipment that they may use during an engagement.
 
 ## [35] Hunter
 
 ![AI preview](../../assets/ai-35.jpg)
-* Primary Weapon Type: Hunter Primary
-* Secondary Weapon Type: Hunter Secondary
-* Grenade Type: -
-* Health per difficulty
-  * Easy: 450
-  * Normal: 450
-  * Heroic: 550
-  * Legendary: 650
-* Shield per difficulty
-  * Easy: 0
-  * Normal: 0
-  * Heroic: 0
-  * Legendary: 0
-* Species: Hunter
-* Notes: -
+- Primary Weapon Type: Hunter Primary
+- Secondary Weapon Type: Hunter Secondary
+- Grenade Type: -
+- Health per difficulty
+  - Easy: 450
+  - Normal: 450
+  - Heroic: 550
+  - Legendary: 650
+- Shield per difficulty
+  - Easy: 0
+  - Normal: 0
+  - Heroic: 0
+  - Legendary: 0
+- Species: Hunter
+- Notes: -
 
 ## [36] Hunter, Banished
 
 ![AI preview](../../assets/ai-36.jpg)
-* Primary Weapon Type: Banished Hunter Primary
-* Secondary Weapon Type: Banished Hunter Secondary
-* Grenade Type: -
-* Health per difficulty
-  * Easy: 650
-  * Normal: 650
-  * Heroic: 750
-  * Legendary: 850
-* Shield per difficulty
-  * Easy: 0
-  * Normal: 0
-  * Heroic: 0
-  * Legendary: 0
-* Species: Hunter
-* Notes: -
+- Primary Weapon Type: Banished Hunter Primary
+- Secondary Weapon Type: Banished Hunter Secondary
+- Grenade Type: -
+- Health per difficulty
+  - Easy: 650
+  - Normal: 650
+  - Heroic: 750
+  - Legendary: 850
+- Shield per difficulty
+  - Easy: 0
+  - Normal: 0
+  - Heroic: 0
+  - Legendary: 0
+- Species: Hunter
+- Notes: -
 
 ## [37] Boss Myriad
 
 ![AI preview](../../assets/ai-37.jpg)
-* Primary Weapon Type: Banished Hunter Primary
-* Secondary Weapon Type: Banished Hunter Secondary
-* Grenade Type: -
-* Health per difficulty
-  * Easy: 1000
-  * Normal: 1000
-  * Heroic: 1100
-  * Legendary: 1200
-* Shield per difficulty
-  * Easy: 0
-  * Normal: 0
-  * Heroic: 0
-  * Legendary: 0
-* Species: Hunter
-* Notes: -
+- Primary Weapon Type: Banished Hunter Primary
+- Secondary Weapon Type: Banished Hunter Secondary
+- Grenade Type: -
+- Health per difficulty
+  - Easy: 1000
+  - Normal: 1000
+  - Heroic: 1100
+  - Legendary: 1200
+- Shield per difficulty
+  - Easy: 0
+  - Normal: 0
+  - Heroic: 0
+  - Legendary: 0
+- Species: Hunter
+- Notes: -
 
 ## [38] Brute Minor
 
 ![AI preview](../../assets/ai-38.jpg)
-* Primary Weapon Type: Mangler
-* Secondary Weapon Type: -
-* Grenade Type: Spike Grenade
-* Health per difficulty
-  * Easy: 140
-  * Normal: 140
-  * Heroic: 170
-  * Legendary: 200
-* Shield per difficulty
-  * Easy: 0
-  * Normal: 0
-  * Heroic: 0
-  * Legendary: 0
-* Species: Brute
-* Notes: Has armor pieces that can be shot off to deal more damage to the unarmored areas.
+- Primary Weapon Type: Mangler
+- Secondary Weapon Type: -
+- Grenade Type: Spike Grenade
+- Health per difficulty
+  - Easy: 140
+  - Normal: 140
+  - Heroic: 170
+  - Legendary: 200
+- Shield per difficulty
+  - Easy: 0
+  - Normal: 0
+  - Heroic: 0
+  - Legendary: 0
+- Species: Brute
+- Notes: Has armor pieces that can be shot off to deal more damage to the unarmored areas.
 
 ## [39] Brute Berserker
 
 ![AI preview](../../assets/ai-39.jpg)
-* Primary Weapon Type: Brute Fists
-* Secondary Weapon Type: -
-* Grenade Type: Dynamo Grenade
-* Health per difficulty
-  * Easy: 250
-  * Normal: 250
-  * Heroic: 300
-  * Legendary: 350
-* Shield per difficulty
-  * Easy: 0
-  * Normal: 0
-  * Heroic: 0
-  * Legendary: 0
-* Species: Brute
-* Notes: Has armor pieces that can be shot off to deal more damage to the unarmored areas.
+- Primary Weapon Type: Brute Fists
+- Secondary Weapon Type: -
+- Grenade Type: Dynamo Grenade
+- Health per difficulty
+  - Easy: 250
+  - Normal: 250
+  - Heroic: 300
+  - Legendary: 350
+- Shield per difficulty
+  - Easy: 0
+  - Normal: 0
+  - Heroic: 0
+  - Legendary: 0
+- Species: Brute
+- Notes: Has armor pieces that can be shot off to deal more damage to the unarmored areas.
 
 ## [40] Brute Berserker, Chosen
 
 ![AI preview](../../assets/ai-40.jpg)
-* Primary Weapon Type: Brute Fists
-* Secondary Weapon Type: -
-* Grenade Type: Dynamo Grenade
-* Health per difficulty
-  * Easy: 250
-  * Normal: 250
-  * Heroic: 300
-  * Legendary: 350
-* Shield per difficulty
-  * Easy: 120
-  * Normal: 120
-  * Heroic: 120
-  * Legendary: 120
-* Species: Brute
-* Notes: Has armor pieces that can be shot off to deal more damage to the unarmored areas.
+- Primary Weapon Type: Brute Fists
+- Secondary Weapon Type: -
+- Grenade Type: Dynamo Grenade
+- Health per difficulty
+  - Easy: 250
+  - Normal: 250
+  - Heroic: 300
+  - Legendary: 350
+- Shield per difficulty
+  - Easy: 120
+  - Normal: 120
+  - Heroic: 120
+  - Legendary: 120
+- Species: Brute
+- Notes: Has armor pieces that can be shot off to deal more damage to the unarmored areas.
 
 ## [41] Brute Commando
 
 ![AI preview](../../assets/ai-41.jpg)
-* Primary Weapon Type: VK78 Commando Rifle
-* Secondary Weapon Type: -
-* Grenade Type: Spike Grenade
-* Health per difficulty
-  * Easy: 175
-  * Normal: 175
-  * Heroic: 212.5
-  * Legendary: 250
-* Shield per difficulty
-  * Easy: 0
-  * Normal: 0
-  * Heroic: 0
-  * Legendary: 0
-* Species: Brute
-* Notes: Has armor pieces that can be shot off to deal more damage to the unarmored areas.
+- Primary Weapon Type: VK78 Commando Rifle
+- Secondary Weapon Type: -
+- Grenade Type: Spike Grenade
+- Health per difficulty
+  - Easy: 175
+  - Normal: 175
+  - Heroic: 212.5
+  - Legendary: 250
+- Shield per difficulty
+  - Easy: 0
+  - Normal: 0
+  - Heroic: 0
+  - Legendary: 0
+- Species: Brute
+- Notes: Has armor pieces that can be shot off to deal more damage to the unarmored areas.
 
 ## [42] Brute Commando, Chosen
 
 ![AI preview](../../assets/ai-42.jpg)
-* Primary Weapon Type: CQS48 Bulldog
-* Secondary Weapon Type: -
-* Grenade Type: Spike Grenade
-* Health per difficulty
-  * Easy: 140
-  * Normal: 140
-  * Heroic: 170
-  * Legendary: 200
-* Shield per difficulty
-  * Easy: 90
-  * Normal: 90
-  * Heroic: 90
-  * Legendary: 90
-* Species: Brute
-* Notes: Has armor pieces that can be shot off to deal more damage to the unarmored areas.
+- Primary Weapon Type: CQS48 Bulldog
+- Secondary Weapon Type: -
+- Grenade Type: Spike Grenade
+- Health per difficulty
+  - Easy: 140
+  - Normal: 140
+  - Heroic: 170
+  - Legendary: 200
+- Shield per difficulty
+  - Easy: 90
+  - Normal: 90
+  - Heroic: 90
+  - Legendary: 90
+- Species: Brute
+- Notes: Has armor pieces that can be shot off to deal more damage to the unarmored areas.
 
 ## [43] Brute Warrior
 
 ![AI preview](../../assets/ai-43.jpg)
-* Primary Weapon Type: CQS48 Bulldog
-* Secondary Weapon Type: -
-* Grenade Type: Spike Grenade
-* Health per difficulty
-  * Easy: 196
-  * Normal: 196
-  * Heroic: 238
-  * Legendary: 280
-* Shield per difficulty
-  * Easy: 0
-  * Normal: 0
-  * Heroic: 0
-  * Legendary: 0
-* Species: Brute
-* Notes: Has armor pieces that can be shot off to deal more damage to the unarmored areas.
+- Primary Weapon Type: CQS48 Bulldog
+- Secondary Weapon Type: -
+- Grenade Type: Spike Grenade
+- Health per difficulty
+  - Easy: 196
+  - Normal: 196
+  - Heroic: 238
+  - Legendary: 280
+- Shield per difficulty
+  - Easy: 0
+  - Normal: 0
+  - Heroic: 0
+  - Legendary: 0
+- Species: Brute
+- Notes: Has armor pieces that can be shot off to deal more damage to the unarmored areas.
 
 ## [44] Brute Warrior, Chosen
 
 ![AI preview](../../assets/ai-44.jpg)
-* Primary Weapon Type: CQS48 Bulldog
-* Secondary Weapon Type: Mangler
-* Grenade Type: Spike Grenade
-* Health per difficulty
-  * Easy: 140
-  * Normal: 140
-  * Heroic: 170
-  * Legendary: 200
-* Shield per difficulty
-  * Easy: 120
-  * Normal: 120
-  * Heroic: 150
-  * Legendary: 180
-* Species: Brute
-* Notes: Has armor pieces that can be shot off to deal more damage to the unarmored areas.
+- Primary Weapon Type: CQS48 Bulldog
+- Secondary Weapon Type: Mangler
+- Grenade Type: Spike Grenade
+- Health per difficulty
+  - Easy: 140
+  - Normal: 140
+  - Heroic: 170
+  - Legendary: 200
+- Shield per difficulty
+  - Easy: 120
+  - Normal: 120
+  - Heroic: 150
+  - Legendary: 180
+- Species: Brute
+- Notes: Has armor pieces that can be shot off to deal more damage to the unarmored areas.
 
 ## [45] Brute Sniper
 
 ![AI preview](../../assets/ai-45.jpg)
-* Primary Weapon Type: Skewer
-* Secondary Weapon Type: Mangler
-* Grenade Type: Spike Grenade
-* Health per difficulty
-  * Easy: 150
-  * Normal: 150
-  * Heroic: 175
-  * Legendary: 200
-* Shield per difficulty
-  * Easy: 0
-  * Normal: 0
-  * Heroic: 0
-  * Legendary: 0
-* Species: Brute
-* Notes: Has armor pieces that can be shot off to deal more damage to the unarmored areas.
+- Primary Weapon Type: Skewer
+- Secondary Weapon Type: Mangler
+- Grenade Type: Spike Grenade
+- Health per difficulty
+  - Easy: 150
+  - Normal: 150
+  - Heroic: 175
+  - Legendary: 200
+- Shield per difficulty
+  - Easy: 0
+  - Normal: 0
+  - Heroic: 0
+  - Legendary: 0
+- Species: Brute
+- Notes: Has armor pieces that can be shot off to deal more damage to the unarmored areas.
 
 ## [46] Brute Sniper, Heavy
 
 ![AI preview](../../assets/ai-46.jpg)
-* Primary Weapon Type: Shock Rifle
-* Secondary Weapon Type: Disruptor
-* Grenade Type: Spike Grenade
-* Health per difficulty
-  * Easy: 150
-  * Normal: 150
-  * Heroic: 175
-  * Legendary: 200
-* Shield per difficulty
-  * Easy: 0
-  * Normal: 0
-  * Heroic: 0
-  * Legendary: 0
-* Species: Brute
-* Notes: Has armor pieces that can be shot off to deal more damage to the unarmored areas.
+- Primary Weapon Type: Shock Rifle
+- Secondary Weapon Type: Disruptor
+- Grenade Type: Spike Grenade
+- Health per difficulty
+  - Easy: 150
+  - Normal: 150
+  - Heroic: 175
+  - Legendary: 200
+- Shield per difficulty
+  - Easy: 0
+  - Normal: 0
+  - Heroic: 0
+  - Legendary: 0
+- Species: Brute
+- Notes: Has armor pieces that can be shot off to deal more damage to the unarmored areas.
 
 ## [47] Brute Warlord
 
 ![AI preview](../../assets/ai-47.jpg)
-* Primary Weapon Type: Heatwave
-* Secondary Weapon Type: -
-* Grenade Type: Spike Grenade
-* Health per difficulty
-  * Easy: 400
-  * Normal: 400
-  * Heroic: 435
-  * Legendary: 470
-* Shield per difficulty
-  * Easy: 120
-  * Normal: 120
-  * Heroic: 150
-  * Legendary: 180
-* Species: Brute
-* Notes: Has armor pieces that can be shot off to deal more damage to the unarmored areas. Has a jetpack that they can use to jump any length or height nav jump hint.
+- Primary Weapon Type: Heatwave
+- Secondary Weapon Type: -
+- Grenade Type: Spike Grenade
+- Health per difficulty
+  - Easy: 400
+  - Normal: 400
+  - Heroic: 435
+  - Legendary: 470
+- Shield per difficulty
+  - Easy: 120
+  - Normal: 120
+  - Heroic: 150
+  - Legendary: 180
+- Species: Brute
+- Notes: Has armor pieces that can be shot off to deal more damage to the unarmored areas. Has a jetpack that they can use to jump any length or height nav jump hint.
 
 ## [48] Brute Captain
 
 ![AI preview](../../assets/ai-48.jpg)
-* Primary Weapon Type: Ravager
-* Secondary Weapon Type: -
-* Grenade Type: Spike Grenade
-* Health per difficulty
-  * Easy: 360
-  * Normal: 360
-  * Heroic: 392.5
-  * Legendary: 425
-* Shield per difficulty
-  * Easy: 0
-  * Normal: 0
-  * Heroic: 0
-  * Legendary: 0
-* Species: Brute
-* Notes: Has armor pieces that can be shot off to deal more damage to the unarmored areas. Has a jetpack that they can use to jump any length or height nav jump hint.
+- Primary Weapon Type: Ravager
+- Secondary Weapon Type: -
+- Grenade Type: Spike Grenade
+- Health per difficulty
+  - Easy: 360
+  - Normal: 360
+  - Heroic: 392.5
+  - Legendary: 425
+- Shield per difficulty
+  - Easy: 0
+  - Normal: 0
+  - Heroic: 0
+  - Legendary: 0
+- Species: Brute
+- Notes: Has armor pieces that can be shot off to deal more damage to the unarmored areas. Has a jetpack that they can use to jump any length or height nav jump hint.
 
 ## [49] Brute Captain, Chosen
 
 ![AI preview](../../assets/ai-49.jpg)
-* Primary Weapon Type: MLRS-2 Hydra
-* Secondary Weapon Type: -
-* Grenade Type: Spike Grenade
-* Health per difficulty
-  * Easy: 400
-  * Normal: 400
-  * Heroic: 435
-  * Legendary: 470
-* Shield per difficulty
-  * Easy: 120
-  * Normal: 120
-  * Heroic: 150
-  * Legendary: 180
-* Species: Brute
-* Notes: Has armor pieces that can be shot off to deal more damage to the unarmored areas. Has a jetpack that they can use to jump any length or height nav jump hint.
+- Primary Weapon Type: MLRS-2 Hydra
+- Secondary Weapon Type: -
+- Grenade Type: Spike Grenade
+- Health per difficulty
+  - Easy: 400
+  - Normal: 400
+  - Heroic: 435
+  - Legendary: 470
+- Shield per difficulty
+  - Easy: 120
+  - Normal: 120
+  - Heroic: 150
+  - Legendary: 180
+- Species: Brute
+- Notes: Has armor pieces that can be shot off to deal more damage to the unarmored areas. Has a jetpack that they can use to jump any length or height nav jump hint.
 
 ## [50] Brute Chieftain
 
 ![AI preview](../../assets/ai-50.jpg)
-* Primary Weapon Type: Gravity Hammer
-* Secondary Weapon Type: -
-* Grenade Type: Spike Grenade
-* Health per difficulty
-  * Easy: 780
-  * Normal: 780
-  * Heroic: 950
-  * Legendary: 1120
-* Shield per difficulty
-  * Easy: 0
-  * Normal: 0
-  * Heroic: 0
-  * Legendary: 0
-* Species: Brute
-* Notes: Has armor pieces that can be shot off to deal more damage to the unarmored areas. Their melee attack deals an EMP shock to nearby vehicles. Can not wield any other weapon than their default.
+- Primary Weapon Type: Gravity Hammer
+- Secondary Weapon Type: -
+- Grenade Type: Spike Grenade
+- Health per difficulty
+  - Easy: 780
+  - Normal: 780
+  - Heroic: 950
+  - Legendary: 1120
+- Shield per difficulty
+  - Easy: 0
+  - Normal: 0
+  - Heroic: 0
+  - Legendary: 0
+- Species: Brute
+- Notes: Has armor pieces that can be shot off to deal more damage to the unarmored areas. Their melee attack deals an EMP shock to nearby vehicles. Can not wield any other weapon than their default.
 
 ## [51] Brute Chieftain, Chosen
 
 ![AI preview](../../assets/ai-51.jpg)
-* Primary Weapon Type: Gravity Hammer
-* Secondary Weapon Type: -
-* Grenade Type: Spike Grenade
-* Health per difficulty
-  * Easy: 1120
-  * Normal: 1120
-  * Heroic: 1345
-  * Legendary: 1570
-* Shield per difficulty
-  * Easy: 200
-  * Normal: 200
-  * Heroic: 275
-  * Legendary: 350
-* Species: Brute
-* Notes: Has armor pieces that can be shot off to deal more damage to the unarmored areas. Their melee attack deals an EMP shock to nearby vehicles. Can not wield any other weapon than their default.
+- Primary Weapon Type: Gravity Hammer
+- Secondary Weapon Type: -
+- Grenade Type: Spike Grenade
+- Health per difficulty
+  - Easy: 1120
+  - Normal: 1120
+  - Heroic: 1345
+  - Legendary: 1570
+- Shield per difficulty
+  - Easy: 200
+  - Normal: 200
+  - Heroic: 275
+  - Legendary: 350
+- Species: Brute
+- Notes: Has armor pieces that can be shot off to deal more damage to the unarmored areas. Their melee attack deals an EMP shock to nearby vehicles. Can not wield any other weapon than their default.
 
 ## [52] Brute Chieftain Turret
 
 ![AI preview](../../assets/ai-52.jpg)
-* Primary Weapon Type: Plasma Cannon
-* Secondary Weapon Type: -
-* Grenade Type: Spike Grenade
-* Health per difficulty
-  * Easy: 780
-  * Normal: 780
-  * Heroic: 950
-  * Legendary: 1120
-* Shield per difficulty
-  * Easy: 0
-  * Normal: 0
-  * Heroic: 0
-  * Legendary: 0
-* Species: Brute
-* Notes: Has armor pieces that can be shot off to deal more damage to the unarmored areas. Can not wield any other weapon than their default.
+- Primary Weapon Type: Plasma Cannon
+- Secondary Weapon Type: -
+- Grenade Type: Spike Grenade
+- Health per difficulty
+  - Easy: 780
+  - Normal: 780
+  - Heroic: 950
+  - Legendary: 1120
+- Shield per difficulty
+  - Easy: 0
+  - Normal: 0
+  - Heroic: 0
+  - Legendary: 0
+- Species: Brute
+- Notes: Has armor pieces that can be shot off to deal more damage to the unarmored areas. Can not wield any other weapon than their default.
 
 ## [53] Brute Chieftain Turret, Chosen
 
 ![AI preview](../../assets/ai-53.jpg)
-* Primary Weapon Type: Brute Scrap Cannon (Scrap Cannon variant)
-* Secondary Weapon Type: -
-* Grenade Type: Spike Grenade
-* Health per difficulty
-  * Easy: 1120
-  * Normal: 1120
-  * Heroic: 1345
-  * Legendary: 1570
-* Shield per difficulty
-  * Easy: 200
-  * Normal: 200
-  * Heroic: 275
-  * Legendary: 350
-* Species: Brute
-* Notes: Has armor pieces that can be shot off to deal more damage to the unarmored areas. Can not wield any other weapon than their default.
+- Primary Weapon Type: Brute Scrap Cannon (Scrap Cannon variant)
+- Secondary Weapon Type: -
+- Grenade Type: Spike Grenade
+- Health per difficulty
+  - Easy: 1120
+  - Normal: 1120
+  - Heroic: 1345
+  - Legendary: 1570
+- Shield per difficulty
+  - Easy: 200
+  - Normal: 200
+  - Heroic: 275
+  - Legendary: 350
+- Species: Brute
+- Notes: Has armor pieces that can be shot off to deal more damage to the unarmored areas. Can not wield any other weapon than their default.
 
 ## [54] Boss Arthoc
 
 ![AI preview](../../assets/ai-54.jpg)
-* Primary Weapon Type: Ravager Rebound
-* Secondary Weapon Type: -
-* Grenade Type: Spike Grenade
-* Health per difficulty
-  * Easy: 895
-  * Normal: 895
-  * Heroic: 1008
-  * Legendary: 1120
-* Shield per difficulty
-  * Easy: 300
-  * Normal: 300
-  * Heroic: 375
-  * Legendary: 450
-* Species: Brute
-* Notes: Has armor pieces that can be shot off to deal more damage to the unarmored areas. Has a jetpack that they can use to jump any length or height nav jump hint.
+- Primary Weapon Type: Ravager Rebound
+- Secondary Weapon Type: -
+- Grenade Type: Spike Grenade
+- Health per difficulty
+  - Easy: 895
+  - Normal: 895
+  - Heroic: 1008
+  - Legendary: 1120
+- Shield per difficulty
+  - Easy: 300
+  - Normal: 300
+  - Heroic: 375
+  - Legendary: 450
+- Species: Brute
+- Notes: Has armor pieces that can be shot off to deal more damage to the unarmored areas. Has a jetpack that they can use to jump any length or height nav jump hint.
 
 ## [55] Boss Balkarus
 
 ![AI preview](../../assets/ai-55.jpg)
-* Primary Weapon Type: Plasma Cannon
-* Secondary Weapon Type: Riven Mangler
-* Grenade Type: Spike Grenade
-* Health per difficulty
-  * Easy: 895
-  * Normal: 895
-  * Heroic: 1008
-  * Legendary: 1120
-* Shield per difficulty
-  * Easy: 300
-  * Normal: 300
-  * Heroic: 375
-  * Legendary: 450
-* Species: Brute
-* Notes: Has armor pieces that can be shot off to deal more damage to the unarmored areas. Has a jetpack that they can use to jump any length or height nav jump hint.
+- Primary Weapon Type: Plasma Cannon
+- Secondary Weapon Type: Riven Mangler
+- Grenade Type: Spike Grenade
+- Health per difficulty
+  - Easy: 895
+  - Normal: 895
+  - Heroic: 1008
+  - Legendary: 1120
+- Shield per difficulty
+  - Easy: 300
+  - Normal: 300
+  - Heroic: 375
+  - Legendary: 450
+- Species: Brute
+- Notes: Has armor pieces that can be shot off to deal more damage to the unarmored areas. Has a jetpack that they can use to jump any length or height nav jump hint.
 
 ## [56] Boss Bassus
 
 ![AI preview](../../assets/ai-56.jpg)
-* Primary Weapon Type: Gravity Hammer
-* Secondary Weapon Type: -
-* Grenade Type: Plasma Grenade
-* Health per difficulty
-  * Easy: 1790
-  * Normal: 1790
-  * Heroic: 2125
-  * Legendary: 2640
-* Shield per difficulty
-  * Easy: 425
-  * Normal: 425
-  * Heroic: 588
-  * Legendary: 750
-* Species: Brute
-* Notes: Has armor pieces that can be shot off to deal more damage to the unarmored areas. Their melee attack deals an EMP shock to nearby vehicles. Can not wield any other weapon than their default.
+- Primary Weapon Type: Gravity Hammer
+- Secondary Weapon Type: -
+- Grenade Type: Plasma Grenade
+- Health per difficulty
+  - Easy: 1790
+  - Normal: 1790
+  - Heroic: 2125
+  - Legendary: 2640
+- Shield per difficulty
+  - Easy: 425
+  - Normal: 425
+  - Heroic: 588
+  - Legendary: 750
+- Species: Brute
+- Notes: Has armor pieces that can be shot off to deal more damage to the unarmored areas. Their melee attack deals an EMP shock to nearby vehicles. Can not wield any other weapon than their default.
 
 ## [57] Boss En'geddon
 
 ![AI preview](../../assets/ai-57.jpg)
-* Primary Weapon Type: Rushdown Hammer
-* Secondary Weapon Type: -
-* Grenade Type: Spike Grenade
-* Health per difficulty
-  * Easy: 1230
-  * Normal: 1230
-  * Heroic: 1400
-  * Legendary: 1570
-* Shield per difficulty
-  * Easy: 400
-  * Normal: 400
-  * Heroic: 500
-  * Legendary: 600
-* Species: Brute
-* Notes: Has armor pieces that can be shot off to deal more damage to the unarmored areas.
+- Primary Weapon Type: Rushdown Hammer
+- Secondary Weapon Type: -
+- Grenade Type: Spike Grenade
+- Health per difficulty
+  - Easy: 1230
+  - Normal: 1230
+  - Heroic: 1400
+  - Legendary: 1570
+- Shield per difficulty
+  - Easy: 400
+  - Normal: 400
+  - Heroic: 500
+  - Legendary: 600
+- Species: Brute
+- Notes: Has armor pieces that can be shot off to deal more damage to the unarmored areas.
 
 ## [58] Boss Ik'novus
 
 ![AI preview](../../assets/ai-58.jpg)
-* Primary Weapon Type: Brute Scrap Cannon (Scrap Cannon variant)
-* Secondary Weapon Type: -
-* Grenade Type: -
-* Health per difficulty
-  * Easy: 1230
-  * Normal: 1230
-  * Heroic: 1400
-  * Legendary: 1570
-* Shield per difficulty
-  * Easy: 300
-  * Normal: 300
-  * Heroic: 375
-  * Legendary: 450
-* Species: Brute
-* Notes: Has armor pieces that can be shot off to deal more damage to the unarmored areas.
+- Primary Weapon Type: Brute Scrap Cannon (Scrap Cannon variant)
+- Secondary Weapon Type: -
+- Grenade Type: -
+- Health per difficulty
+  - Easy: 1230
+  - Normal: 1230
+  - Heroic: 1400
+  - Legendary: 1570
+- Shield per difficulty
+  - Easy: 300
+  - Normal: 300
+  - Heroic: 375
+  - Legendary: 450
+- Species: Brute
+- Notes: Has armor pieces that can be shot off to deal more damage to the unarmored areas.
 
 ## [59] Boss Zeretus
 
 ![AI preview](../../assets/ai-59.jpg)
-* Primary Weapon Type: M41 Tracker
-* Secondary Weapon Type: -
-* Grenade Type: Spike Grenade
-* Health per difficulty
-  * Easy: 895
-  * Normal: 895
-  * Heroic: 1008
-  * Legendary: 1120
-* Shield per difficulty
-  * Easy: 300
-  * Normal: 300
-  * Heroic: 375
-  * Legendary: 450
-* Species: Brute
-* Notes: Has armor pieces that can be shot off to deal more damage to the unarmored areas. Has a jetpack that they can use to jump any length or height nav jump hint.
+- Primary Weapon Type: M41 Tracker
+- Secondary Weapon Type: -
+- Grenade Type: Spike Grenade
+- Health per difficulty
+  - Easy: 895
+  - Normal: 895
+  - Heroic: 1008
+  - Legendary: 1120
+- Shield per difficulty
+  - Easy: 300
+  - Normal: 300
+  - Heroic: 375
+  - Legendary: 450
+- Species: Brute
+- Notes: Has armor pieces that can be shot off to deal more damage to the unarmored areas. Has a jetpack that they can use to jump any length or height nav jump hint.
 
 ## [60] Boss Tovarus
 
 ![AI preview](../../assets/ai-60.jpg)
-* Primary Weapon Type: Brute Scrap Cannon (Scrap Cannon variant)
-* Secondary Weapon Type: -
-* Grenade Type: Spike Grenade
-* Health per difficulty
-  * Easy: 1600
-  * Normal: 1600
-  * Heroic: 1900
-  * Legendary: 2200
-* Shield per difficulty
-  * Easy: 400
-  * Normal: 400
-  * Heroic: 500
-  * Legendary: 600
-* Species: Brute
-* Notes: Has armor pieces that can be shot off to deal more damage to the unarmored areas. Has a jetpack that they can use to jump any length or height nav jump hint.
+- Primary Weapon Type: Brute Scrap Cannon (Scrap Cannon variant)
+- Secondary Weapon Type: -
+- Grenade Type: Spike Grenade
+- Health per difficulty
+  - Easy: 1600
+  - Normal: 1600
+  - Heroic: 1900
+  - Legendary: 2200
+- Shield per difficulty
+  - Easy: 400
+  - Normal: 400
+  - Heroic: 500
+  - Legendary: 600
+- Species: Brute
+- Notes: Has armor pieces that can be shot off to deal more damage to the unarmored areas. Has a jetpack that they can use to jump any length or height nav jump hint.
 
 ## [61] Boss Hyperius
 
 ![AI preview](../../assets/ai-61.jpg)
-* Primary Weapon Type: Ravager
-* Secondary Weapon Type: S7 Sniper Rifle
-* Grenade Type: Spike Grenade
-* Health per difficulty
-  * Easy: 1400
-  * Normal: 1400
-  * Heroic: 1512
-  * Legendary: 1624
-* Shield per difficulty
-  * Easy: 300
-  * Normal: 300
-  * Heroic: 400
-  * Legendary: 500
-* Species: Brute
-* Notes: Has armor pieces that can be shot off to deal more damage to the unarmored areas. Has a jetpack that they can use to jump any length or height nav jump hint.
+- Primary Weapon Type: Ravager
+- Secondary Weapon Type: S7 Sniper Rifle
+- Grenade Type: Spike Grenade
+- Health per difficulty
+  - Easy: 1400
+  - Normal: 1400
+  - Heroic: 1512
+  - Legendary: 1624
+- Shield per difficulty
+  - Easy: 300
+  - Normal: 300
+  - Heroic: 400
+  - Legendary: 500
+- Species: Brute
+- Notes: Has armor pieces that can be shot off to deal more damage to the unarmored areas. Has a jetpack that they can use to jump any length or height nav jump hint.
 
 ## [62] Boss Tremonius
 
 ![AI preview](../../assets/ai-62.jpg)
-* Primary Weapon Type: MLRS-2 Hydra
-* Secondary Weapon Type: CQS48 Bulldog
-* Grenade Type: Frag Grenade
-* Health per difficulty
-  * Easy: 1000
-  * Normal: 1000
-  * Heroic: 1175
-  * Legendary: 1359
-* Shield per difficulty
-  * Easy: 450
-  * Normal: 450
-  * Heroic: 575
-  * Legendary: 700
-* Species: Brute
-* Notes: Has armor pieces that can be shot off to deal more damage to the unarmored areas. Has a jetpack that they can use to jump any length or height nav jump hint.
+- Primary Weapon Type: MLRS-2 Hydra
+- Secondary Weapon Type: CQS48 Bulldog
+- Grenade Type: Frag Grenade
+- Health per difficulty
+  - Easy: 1000
+  - Normal: 1000
+  - Heroic: 1175
+  - Legendary: 1359
+- Shield per difficulty
+  - Easy: 450
+  - Normal: 450
+  - Heroic: 575
+  - Legendary: 700
+- Species: Brute
+- Notes: Has armor pieces that can be shot off to deal more damage to the unarmored areas. Has a jetpack that they can use to jump any length or height nav jump hint.
 
 ## [63] Boss Escharum
 
 ![AI preview](../../assets/ai-63.jpg)
-* Primary Weapon Type: Brute Scrap Cannon (Scrap Cannon variant)
-* Secondary Weapon Type: Diminisher of Hope
-* Grenade Type: Spike Grenade
-* Health per difficulty
-  * Easy: 7000
-  * Normal: 7000
-  * Heroic: 8000
-  * Legendary: 9000
-* Shield per difficulty
-  * Easy: 800
-  * Normal: 800
-  * Heroic: 800
-  * Legendary: 800
-* Species: Brute
-* Notes: Has armor pieces that can be shot off to deal more damage to the unarmored areas. Has a red bubble shield that needs to be destroyed 5 times before he swaps to the Diminisher of Hope and doesn't gain back the shield anymore.
+- Primary Weapon Type: Brute Scrap Cannon (Scrap Cannon variant)
+- Secondary Weapon Type: Diminisher of Hope
+- Grenade Type: Spike Grenade
+- Health per difficulty
+  - Easy: 7000
+  - Normal: 7000
+  - Heroic: 8000
+  - Legendary: 9000
+- Shield per difficulty
+  - Easy: 800
+  - Normal: 800
+  - Heroic: 800
+  - Legendary: 800
+- Species: Brute
+- Notes: Has armor pieces that can be shot off to deal more damage to the unarmored areas. Has a red bubble shield that needs to be destroyed 5 times before he swaps to the Diminisher of Hope and doesn't gain back the shield anymore.
 
 ## [64] Boss Adjutant Resolution, Silver
 
 ![AI preview](../../assets/ai-64.jpg)
-* Primary Weapon Type: Silver Sentry Primary (Pulse Carbine variant)
-* Secondary Weapon Type: Silver Sentry Secondary (Cindershot variant)
-* Tertiary Weapon Type: Sentry Tertiary (Sentinel Beam variant)
-* Grenade Type: -
-* Health per difficulty
-  * Easy: 2640
-  * Normal: 2640
-  * Heroic: 2640
-  * Legendary: 2640
-* Shield per difficulty
-  * Easy: 0
-  * Normal: 0
-  * Heroic: 0
-  * Legendary: 0
-* Species: Sentinel
-* Notes: Has different stages of offense. The outer arms must be shot out before being able to kill it.
+- Primary Weapon Type: Silver Sentry Primary (Pulse Carbine variant)
+- Secondary Weapon Type: Silver Sentry Secondary (Cindershot variant)
+- Tertiary Weapon Type: Sentry Tertiary (Sentinel Beam variant)
+- Grenade Type: -
+- Health per difficulty
+  - Easy: 2640
+  - Normal: 2640
+  - Heroic: 2640
+  - Legendary: 2640
+- Shield per difficulty
+  - Easy: 0
+  - Normal: 0
+  - Heroic: 0
+  - Legendary: 0
+- Species: Sentinel
+- Notes: Has different stages of offense. The outer arms must be shot out before being able to kill it.
 
 ## [65] Boss Adjutant Resolution, Gold
 
 ![AI preview](../../assets/ai-65.jpg)
-* Primary Weapon Type: Gold Sentry Primary (Scrap Cannon variant)
-* Secondary Weapon Type: Gold Sentry Secondary (M41 SPNKr variant)
-* Tertiary Weapon Type: Sentry Tertiary (Sentinel Beam variant)
-* Grenade Type: -
-* Health per difficulty
-  * Easy: 3170
-  * Normal: 3170
-  * Heroic: 3170
-  * Legendary: 3170
-* Shield per difficulty
-  * Easy: 0
-  * Normal: 0
-  * Heroic: 0
-  * Legendary: 0
-* Species: Sentinel
-* Notes: Has different stages of offense. The outer arms must be shot out before being able to kill it.
+- Primary Weapon Type: Gold Sentry Primary (Scrap Cannon variant)
+- Secondary Weapon Type: Gold Sentry Secondary (M41 SPNKr variant)
+- Tertiary Weapon Type: Sentry Tertiary (Sentinel Beam variant)
+- Grenade Type: -
+- Health per difficulty
+  - Easy: 3170
+  - Normal: 3170
+  - Heroic: 3170
+  - Legendary: 3170
+- Shield per difficulty
+  - Easy: 0
+  - Normal: 0
+  - Heroic: 0
+  - Legendary: 0
+- Species: Sentinel
+- Notes: Has different stages of offense. The outer arms must be shot out before being able to kill it.
 
 ## [66] Boss Harbinger
 
 ![AI preview](../../assets/ai-66.jpg)
-* Primary Weapon Type: Harbinger Primary (Unique)
-* Secondary Weapon Type: -
-* Grenade Type: -
-* Health per difficulty
-  * Easy: 200
-  * Normal: 200
-  * Heroic: 200
-  * Legendary: 200
-* Shield per difficulty
-  * Easy: 800
-  * Normal: 800
-  * Heroic: 1025
-  * Legendary: 1250
-* Species: ?
-* Notes: Shoots blue orbs that charge up mid-air and track to the nearest enemy. Impacts of the shots leave a lingering damage effect. The AI teleports around when engaging an enemy.
+- Primary Weapon Type: Harbinger Primary (Unique)
+- Secondary Weapon Type: -
+- Grenade Type: -
+- Health per difficulty
+  - Easy: 200
+  - Normal: 200
+  - Heroic: 200
+  - Legendary: 200
+- Shield per difficulty
+  - Easy: 800
+  - Normal: 800
+  - Heroic: 1025
+  - Legendary: 1250
+- Species: ?
+- Notes: Shoots blue orbs that charge up mid-air and track to the nearest enemy. Impacts of the shots leave a lingering damage effect. The AI teleports around when engaging an enemy.
 
 ## Acknowledgements
 


### PR DESCRIPTION
## Changes

**Adjusted:**

Weapons:
- [37] Spike Off Ordo 'Mal:
	- Weapon Name: Spike Off Ordo 'Mal: -> Spike Off Thav 'Sebarim
- [42] Forklift Warrior:
	- Sprint Enabled: FALSE (remove)

**Chores:**

- Changed unordered list symbols for some docs files.
- Fixed the [37] Spike Off Ordo 'Mal Weapon Type combo.

## Spike Off Ordo 'Mal rename

After adjusting our AI configs, and giving Thav 'Sebarim the [37] Spike Off Ordo 'Mal, we've decided it would be fitting to change the weapon's name to "Spike Off Thav 'Sebarim" instead, so the weapon name now has a true connection in our Warzone universe.

## Forklift Warrior sprint returning

We felt that disabling sprinting while holding the [42] Forklift Warrior was too big of a disadvantage to holding the weapon that we've decided to return the ability to sprint while holding the weapon.