### PR TITLE
Speed Boost overhaul, movement trait buffs & Sandwich nerf

### DIFF
--- a/docs/items/ability-boost-configs.md
+++ b/docs/items/ability-boost-configs.md
@@ -104,13 +104,10 @@ The configurations that make up each of the ability boosts.
 
 ## [5] Upgraded Walking
 - Trait Set: upgradedWalking
-  - Movement Speed: 1.10
-  - Jump Height: 1.10
-  - Sprint Speed
-    - Top Speed Scalar: 0.95
-    - Time To Top Speed Scalar: 1.00
+  - Movement Speed: 1.13
+  - Jump Height: 1.25
   - Slide Speed
-    - Slide Speed Scalar: 0.93
+    - Slide Speed Scalar: 0.85
     - Slide Duration Scalar: 1.00
 - Game State: 3
 - Notes: -

--- a/docs/items/ability-boost-configs.md
+++ b/docs/items/ability-boost-configs.md
@@ -118,7 +118,7 @@ The configurations that make up each of the ability boosts.
 ## [6] Upgraded Sprinting
 - Trait Set: upgradedSprinting
   - Sprint Speed
-    - Top Speed Scalar: 1.13
+    - Top Speed Scalar: 1.25
     - Time To Top Speed Scalar: 0.90
   - Slide Speed
     - Slide Speed Scalar: 1.10

--- a/docs/items/equipment-configs.md
+++ b/docs/items/equipment-configs.md
@@ -161,31 +161,20 @@ The configurations that make up each of the equipment, including custom powerups
 
 ## [13] Speed Boost
 - Equipment Type: Custom Equipment C
-- Trait Set 1: speedboost1
-  - Movement Speed: 1.10
-  - Jump Height: 1.10
+- Trait Sets: speedboost1 & speedboost2 & speedboost3 & speedboost4
+  - Movement Speed: 1.16
   - Sprint Speed
-    - Top Speed Scalar: 0.95
+    - Top Speed Scalar: 1.13
     - Time To Top Speed Scalar: 1.00
   - Slide Speed
     - Slide Speed Scalar: 0.93
-    - Slide Duration Scalar: 1.00
-  - Slide Speed
-    - Slide Speed Scalar: 0.99
-    - Slide Duration Scalar: 1.00
-- Trait Set 2: speedBoost2
-  - Sprint Speed
-    - Top Speed Scalar: 1.13
-    - Time To Top Speed Scalar: 0.90
-  - Slide Speed
-    - Slide Speed Scalar: 1.10
     - Slide Duration Scalar: 1.00
 - Charge Count: 1
 - Duration: 45 s
 - VFX: None
 - REQ Tier: 2
 - Game State: 1
-- Notes: Combines the upgradedWalking and upgradedSprinting ability boosts for the best of both. Trait sets are identical, but separate declarations so they can be individually turned on and off without intereference.
+- Notes: Has four identical traits that can be stacked for a total of four Speed Boosts. Stacking multiple traits multiplies their scalars.
 
 ## [14] Headhunter Guard
 - Equipment Type: Custom Equipment D

--- a/docs/items/weapon-configs.md
+++ b/docs/items/weapon-configs.md
@@ -409,7 +409,7 @@ The configurations that make up each of the custom weapons.
 ## [32] Spartan Sandwich
 - Weapon Type: Sandwich + Duelist Energy Sword
 - Trait Set: 32
-    - Melee Damage: 2.00
+    - Melee Damage: 0.70
     - Movement Speed: 1.10
 - VFX: Beta Infected
 - Config: Combo


### PR DESCRIPTION
## Changes

**Adjusted:**

Weapons:
- [32] Spartan Sandwich:
    - Melee Damage: 2.00 -> **0.70**

Equipment:
- [13] Speed Boost:
    - Movement Speed: 1.10 ->**1.16**
    - Jump Height: 1.10 -> **(none)**
    - Sprint Speed
	    - Time To Top Speed Scalar: 0.90 -> **1.00**
	- Slide Speed
		- Slide Speed Scalar: 1.10 -> **0.93**
	- Equipment made stackable; trait effects multiply when the equipment is used multiple times.

Ability Boosts:
- [5] Upgraded Walking:
    - Movement Speed: 1.10 -> **1.13**
    - Jump Height: 1.10 -> **1.25**
    - Sprint Speed
	    - Top Speed Scalar: 0.95 -> **(none)**
	    - Time To Top Speed Scalar: 1.00 -> **(none)**
	- Slide Speed
		- Slide Speed Scalar: 0.93 -> **0.85**
- [6] Upgraded Sprinting:
    - Sprint Speed
	    - Top Speed Scalar: 1.13 -> **1.25**

## Spartan Sandwich melee damage decrease

The [32] Spartan Sandwich was initially made to be able to kill an overshielded player in one hit, but we've noticed the damage output is too much for a weapon with unlimited melees. The large damage output also led to issues with the [11] Health Steal equipment, which would grant the user an unrealistic amount of health back from a kill.

We've majorly reduced the melee damage of the weapon while still keeping it a one-hit melee kill against players with default health. This change also makes the weapon less effective at destroying vehicles, as that role should be filled by the Ravager variants, which also have unlimited Sword melee attacks.

The Spartan Sandwich still retains the fastest movement speed and melee recovery speed of any weapon in the sandbox, which should be the main draw of the weapon.

## Speed Boost overhaul

Following feedback from player "Precellence" about the underwhelming impression of the [13] Speed Boost equipment, we've done a big overhaul for both the equipment base traits, but also we've added the ability to stack the equipment four times.

The equipment previously didn't live up to the standards players expected from a Speed Boost powerup, so the base movement speed has been increased, which also increases the sprint speed. The slide speed has been decreased to stop players from accelerating out of control by sliding.

A big addition to the Speed Boost is the ability to now stack a maximum of four Speed Boost equipment, which will each multiply the applied traits, allowing for ridiculous speeds to be achieved like in Halo 5. Purchasing four Speed Boosts costs 8 total REQ tiers, and they only last for 45 seconds, which we think will keep it balanced with the rest of the sandbox offering, while still allowing the unique and fun playstyle.

Below is some comparisons of some movement speed velocities between Halo 5 and our Halo Infinite warzone sandbox:

### Walking

**Default**
Halo 5: 24.934
Halo Infinite: 26.175

**Upgraded Walking trait**
Halo 5: -
Halo Infinite: 29.250

**1x Speed Boost**
Halo 5: ?
Halo Infinite: 30.120

### Sprinting

**Default**
Halo 5: 32.972
Halo Infinite: 28.990

**Upgraded Sprinting trait**
Halo 5: -
Halo Infinite: 35.980

**1x Speed Boost**
Halo 5: 39.534
Halo Infinite: 36.780

**2x Speed Boost**
Halo 5: 47.014
Halo Infinite: 46.200

**3x Speed Boost**
Halo 5: 57.185
Halo Infinite: 55.930

**4x Speed Boost**
Halo 5: 68.175
Halo Infinite: 68.180

**4x Speed Boost + Whispered Truth/Spartan Sandwich**
Halo 5: 82.972
Halo Infinite: 83.220

**4x Speed Boost + Spartan Sandwich + Upgraded Sprinting + Sliding**
Halo 5: -
Halo Infinite: up to 110

## Upgraded Walking buff

Following feedback from player "Precellence" about the [5] Upgraded Walking ability boost feeling too underwhelming, we've buffed its base movement speed and jump height.

The Movement Speed was increased slightly from 1.10 to 1.13 to emphasize it, while still keeping it lower than a [13] Speed Boost walk speed. The jump height was increased quite a bit, and was balanced around being able to navigate to the highest level of an Armory from the top platform with a clamber.

### Walking

**Default**
Halo Infinite: 26.175

**Upgraded Walking trait**
Halo Infinite: 29.250

**1x Speed Boost**
Halo Infinite: 30.120

## Upgraded Sprinting buff

Following feedback from player "Precellence" about the [6] Upgraded Sprinting ability boost feeling too underwhelming, we've increased its sprint speed.

The Top Speed Scalar was adjusted from 1.13 to 1.25 to make the speed difference more noticeable and desirable. The sprint speed was kept slightly below that of the [13] Speed Boost, but its still very comparable.

### Sprinting

**Default**
Halo Infinite: 28.990

**Upgraded Sprinting trait**
Halo Infinite: 35.980

**1x Speed Boost**
Halo Infinite: 36.780
