### PR TITLE
Sentry AI encounter addition and Pulse Wave adjustment

### DIFF
--- a/docs/items/weapon-configs.md
+++ b/docs/items/weapon-configs.md
@@ -221,8 +221,8 @@ The configurations that make up each of the custom weapons.
 - Trait Set: 16
   - Weapon Damage: 0.40
 - Config: Combo
-- Ammo Adjustment: -32
-  - 32%
+- Ammo Adjustment: -40
+  - 40%
 - REQ Tier: 5
 - Game State: 4
 - Notes: -

--- a/docs/npc/ai-variants-custom.md
+++ b/docs/npc/ai-variants-custom.md
@@ -55,11 +55,15 @@ Documentation of all the custom AI variants used for the Warzone mode. Only the 
 - Trait Set: -
 - Notes: -
 
-## [6] Jackal Sniper
+## [6] Boss Adjutant Resolution, Gold
 
-![AI preview](../../assets/ai-11.jpg)
+![AI preview](../../assets/ai-65.jpg)
 - Trait Set: ?
-  - Weapon Damage: 1.30
+  - Weapon Damage: 3.00
+  - Damage Resistance
+    - Direct Damage Scalar: 2.00
+    - Grenade Damage Scalar: 0.50
+    - Explosive Damage Scalar: 0.50
 - Notes: -
 
 ## [7] Marine Assault

--- a/docs/npc/encounter-configs.md
+++ b/docs/npc/encounter-configs.md
@@ -105,13 +105,37 @@ The configurations of AI that make up each of the AI encounters.
 - Elite Warlord
 - Elite Ultra
 
-## [11] Team Marines
+## [11] Sentry Encounter, Mythic
+
+- Adjutant Resolution, Gold (Boss)
+- Grunt Ultra
+- Grunt Ultra
+- Elite Warlord
+- Elite Warlord
+- Elite Ultra
+- Elite Ultra
+- Brute Warlord
+- Brute Warlord
+
+## [12] Unallocated
+
+- AI Name
+
+## [13] Unallocated
+
+- AI Name
+
+## [14] Unallocated
+
+- AI Name
+
+## [15] Team Marines
 
 - Marine Assault
 - Marine Assault
 - Marine Assault
 
-## [12] Base Roamers 1
+## [16] Base Roamers 1
 
 - Elite Mercenary
 - Jackal Freebooter
@@ -119,7 +143,7 @@ The configurations of AI that make up each of the AI encounters.
 - Grunt Conscript, Yellow
 - Grunt Conscript, Yellow
 
-## [13] Base Roamers 2
+## [17] Base Roamers 2
 
 - Brute Minor
 - Jackal Raider
@@ -127,13 +151,13 @@ The configurations of AI that make up each of the AI encounters.
 - Grunt Conscript, Yellow
 - Grunt Conscript, Yellow
 
-## [14] Wild Roamers 1
+## [18] Wild Roamers 1
 
 - Elite Mercenary
 - Jackal Freebooter
 - Jackal Freebooter
 
-## [15] Wild Roamers 2
+## [19] Wild Roamers 2
 
 - Brute Minor
 - Jackal Raider


### PR DESCRIPTION
## Changes

**Removed**

AI:
- [6] Jackal Sniper

**Added**

AI:
- [6] Boss Adjutant Resolution, Gold

AI Encounters:
- [11] Sentry Encounter, Mythic

**Adjusted:**

Weapons:
- [16] Pulse Wave:
    - Ammo Adjustment: -32 (32%) -> **-40 (40%)**

AI Encounters:
- Reordered AI Encounter values from 11 onward.

## Jackal Sniper removal

After testing the offensive capabilities of the [6] Jackal Sniper, we've decided to remove them from the gameplay, since they consistently underperform in their ability to be a threat to players. They can also be killed in one shot to the head with headshot-capable weapons, which eliminates them from the battlefield usually before they can get a single shot out towards the players.

## Sentry Encounter, Mythic addition

In our AI encounter testing with random players, we noticed that a bit more variety in the Mythic encounters could still fit in the gameplay, and the Sentry boss type was still available, so we added an encounter for it. The Sentry boss type has a unique progression to the battle, which follows the formula of the other Mythic boss battles as well.

## Boss Adjutant Resolution, Gold addition

The Boss Adjutant Resolution, Gold takes the [6] spot, replacing the Jackal Sniper, to make the scripting work easier, requiring no changes to the existing encounter setups.

## Pulse Wave ammo increase

Following feedback from player "Precellence" about the slightly too low charge capacity for the [16] Pulse Wave, we've increased the charge to 40%. This makes the weapon a bit more stronger against vehicles as well as a better investment at REQ tier 5.