### PR TITLE
Decaying World and Cutlass Off Doomfruit buffs

### DIFF
--- a/docs/items/weapon-configs.md
+++ b/docs/items/weapon-configs.md
@@ -17,12 +17,11 @@ The configurations that make up each of the custom weapons.
     - Direct Damage Scalar: #.##
     - Grenade Damage Scalar: #.##
     - Explosive Damage Scalar: #.##
-- Config: Combo/Projectile/Scripted
+- Config: Combo/Projectile
   - Shot Count: #
   - Shot Velocity: #
   - Projectile Config: #
   - Projectile: Hunter
-  - Scripted behavior: -
 - Ammo Adjustment: None/##
   - #+#
 - REQ Tier: #
@@ -448,25 +447,24 @@ The configurations that make up each of the custom weapons.
   - 75%
 - REQ Tier: 7
 - Game State: 6
-- Notes: -
+- Notes: The second trait set only applies while zoomed.
 
 ## [35] Cutlass Off Doomfruit
 - Weapon Type: Energy Sword + Unbound Plasma Pistol
-- Trait Set: 35
-  - Movement Speed: 0.80
+- Trait Set (while zoomed): 35
+  - Movement Speed: 0.40
   - Damage Resistance
-    - Direct Damage Scalar: 1.55
-    - Grenade Damage Scalar: 0.64
-    - Explosive Damage Scalar: 0.64
-- VFX: VIP (when zoomed)
-- Config: Scripted
-  - Scripted Behavior: 
-    - The "Movement Speed" reduction and "Damage Resistance" increase will only apply when zoomed and not airborne. reduction. 
+    - Direct Damage Scalar: 2.10
+    - Grenade Damage Scalar: 0.476190476
+    - Explosive Damage Scalar: 0.476190476
+  - VFX - Overshield
+- VFX (while zoomed): VIP
+- Config: Combo
 - Ammo Adjustment: None
   - 100%
 - REQ Tier: 4
 - Game State: 3
-- Notes: -
+- Notes: The traits and VFX only apply when zoomed and not airborne.
 
 ## [36] Power Off Jega Rdomnai
 - Weapon Type: Infected Energy Sword + MA40 Longshot

--- a/docs/items/weapon-configs.md
+++ b/docs/items/weapon-configs.md
@@ -273,7 +273,7 @@ The configurations that make up each of the custom weapons.
 ## [21] Decaying World
 - Weapon Type: Disruptor + Diminisher of Hope
 - Trait Set: 21
-  - Weapon damage: 1.87
+  - Weapon damage: 1.89
   - Movement Speed: 1.10
 - Config: Combo
 - Ammo Adjustment: None


### PR DESCRIPTION
## Changes

**Adjusted:**

Weapons:
- [21] Decaying World:
    - Weapon Damage: 1.87 -> **1.89**
- [35] Cutlass Off Doomfruit:
    - Weapon Type: Energy Sword + Unbound Plasma Pistol -> **Infected Energy Sword + Unbound Plasma Pistol**
    - Movement Speed: 0.80 -> **0.40**
    - Damage Resistance
	    - Direct Damage Scalar: 1.55 -> **2.10**
	    - Grenade Damage Scalar: 0.64 -> **0.476190476**
	    - Explosive Damage Scalar: 0.64 -> **0.476190476**
	- **VFX - Overshield**

**Chores:**

- Removed "Config: Scripted" option from weapon config docs.
- Adjusted notes on [34] Sentry Off Writh Kul.

## Decaying World damage increase

Following feedback from player "Unyshek" as well as our own observations, we've slightly increased the damage of the [21] Decaying World. We were noticing inconsistency with the damage-over-time (DOT) effects of the weapon after landing 4 shots on an enemy and supercombining them. When the target was by themselves, 4 shots + DOT would result in a kill, but if they were in a group of 3 players, the 4 shots + DOT on one target wasn't enough to kill the target, as the shock damage seemed to be slightly distributed among the other players.

We've increased the damage of the weapon from 1.87 to 1.89, which solves these inconsistencies, and granting a guaranteed kill with 4 shots + DOT once again.

## Cutlass Off Doomfruit overhaul

After observing various players using the [35] Cutlass Off Doomfruit, and not realizing the unique aspects of the weapon, we've increased the UX communication of the weapon as well as made the special effects of the weapon more apparent in a balanced way.

The base weapon was changed from an Energy Sword to an Infected Energy Sword so set the weapon apart from a normal Energy Sword when looking at the model. The only other Infected Energy Sword base weapon -holding weapon combo in our sandbox is the [36] Power Off Jega Rdomnai, which turns the holder invisible rather quickly, so seeing a player wielding an Infected Energy Sword, but not being invisible should communicate that it's the Cutlass Off Doomfruit. The weapon also has a white handle compared to the Power Off Jega Rdomnai's black handle.

The movement speed while zoomed with the weapon was changed from 0.80 to 0.40 to make the speed change more noticeable. To balance the major movement speed decrease, we've increased the damage resistance of the holder while zoomed to be the same as the damage resistance of the [30] Doom Off Reach. This makes the weapon holder die in two sword hits rather than one, leading to interesting sword clashes. To better the UX communication of the damage resistance to attacking players, we've added an Overshield visual effect to the weapon holder while the traits are active.

The traits are only active when zooming and not airborne using the weapon, meaning that when lunging towards a target, the traits also disengage, leading to some interesting combat situations.