### PR TITLE
Power Arm replacement

### DIFF
--- a/docs/items/ability-boost-configs.md
+++ b/docs/items/ability-boost-configs.md
@@ -87,7 +87,7 @@ The configurations that make up each of the ability boosts.
     - Tactical Reload Scalar: 1.17
   - Weapon Switch Speed: 1.17
   - Clamber Speed: 1.17
-  - Melee Recovery Speed: 1.10
+  - Melee Recovery Speed: 1.40
 - Game State: 3
 - Notes: -
 

--- a/docs/items/equipment-configs.md
+++ b/docs/items/equipment-configs.md
@@ -56,7 +56,7 @@ The configurations that make up each of the equipment, including custom powerups
     - Vehicle Range Scalar: #.##
 - Charge Count: #
 - Duration: ## s
-- VFX: Infected Alpha, Infected Alpha - Screen, Infected Beta, Infected Beta - Screen, VIP, None
+- VFX: Infected Alpha, Infected Beta, VIP, None
 - REQ Tier: #
 - Game State: #
 - Notes: -

--- a/docs/items/equipment-configs.md
+++ b/docs/items/equipment-configs.md
@@ -182,7 +182,7 @@ The configurations that make up each of the equipment, including custom powerups
   - Headshot Protection: TRUE
 - Charge Count: 1
 - Duration: 60 s
-- VFX: VIP
+- VFX: Infected Beta
 - REQ Tier: 3
 - Game State: 2
 - Notes: Makes headshots to unshielded players act like bodyshots. Weapons that can kill an unshielded player in one hit to the head will now require more shots to the head to kill.

--- a/docs/items/equipment-configs.md
+++ b/docs/items/equipment-configs.md
@@ -143,21 +143,21 @@ The configurations that make up each of the equipment, including custom powerups
     - Health Scalar: 0.40
 - Charge Count: 1
 - Duration: 60 s
-- VFX: Infected Alpha, Infected Alpha - Screen
+- VFX: Infected Alpha
 - REQ Tier: 6
 - Game State: 5
 - Notes: Vampirism only comes from dealing damage to enemy health, not shield.
 
-## [12] Power Arm
+## [12] Allied Monitor
 - Equipment Type: Custom Equipment B
-- Trait Set: powerArm
-  - Melee Recovery Speed: 1.80
+- Trait Set: alliedMonitor
+  - Third Person Gameplay: TRUE
 - Charge Count: 1
 - Duration: 45 s
-- VFX: Infected Beta, Infected Beta - Screen
+- VFX: VIP
 - REQ Tier: 2
 - Game State: 1
-- Notes: Can melee faster with any weapon and can melee inert objects further upon impact.
+- Notes: Puts the player's view in third person, allowing for a wider angle of the battlefield.
 
 ## [13] Speed Boost
 - Equipment Type: Custom Equipment C

--- a/docs/items/weapon-configs.md
+++ b/docs/items/weapon-configs.md
@@ -450,7 +450,7 @@ The configurations that make up each of the custom weapons.
 - Notes: The second trait set only applies while zoomed.
 
 ## [35] Cutlass Off Doomfruit
-- Weapon Type: Energy Sword + Unbound Plasma Pistol
+- Weapon Type: Infected Energy Sword + Unbound Plasma Pistol
 - Trait Set (while zoomed): 35
   - Movement Speed: 0.40
   - Damage Resistance

--- a/docs/items/weapon-configs.md
+++ b/docs/items/weapon-configs.md
@@ -168,7 +168,7 @@ The configurations that make up each of the custom weapons.
 - Weapon Type: CQS48 Bulldog + Diminisher Of Hope
 - Trait Set: 12
   - Weapon Damage: 2.90
-- VFX: Beta Infected
+- VFX: Infected Beta
 - Config: Combo
 - Ammo Adjustment: None
   - 7+7
@@ -180,7 +180,7 @@ The configurations that make up each of the custom weapons.
 - Weapon Type: S7 Sniper Rifle + Diminisher of Hope
 - Trait Set: 13
   - Weapon Damage: 1.61
-- VFX: Alpha Infected
+- VFX: Infected Alpha
 - Config: Projectile
   - Shot Count: 1
   - Shot Velocity: 3000
@@ -262,7 +262,7 @@ The configurations that make up each of the custom weapons.
 - Weapon Type: Ravager + Duelist Energy Sword
 - Trait Set: 20
   - Weapon Damage: 1.61
-- VFX: Beta Infected
+- VFX: Infected Beta
 - Config: Combo
 - Ammo Adjustment: None
   - 100%
@@ -317,7 +317,7 @@ The configurations that make up each of the custom weapons.
 - Weapon Type: Sentinel Beam + Striker Sidekick
 - Trait Set: 25
   - Weapon Damage: 0.70
-- VFX: Beta Infected
+- VFX: Infected Beta
 - Config: Combo
 - Ammo Adjustment: 50
   - 14+84
@@ -384,7 +384,7 @@ The configurations that make up each of the custom weapons.
     - Direct Damage Scalar: 2.10
     - Grenade Damage Scalar: 0.476190476
     - Explosive Damage Scalar: 0.476190476
-- VFX: Alpha Infected
+- VFX: Infected Alpha
 - Config: Combo
 - Ammo Adjustment: None
   - 100%
@@ -410,7 +410,7 @@ The configurations that make up each of the custom weapons.
 - Trait Set: 32
     - Melee Damage: 0.70
     - Movement Speed: 1.10
-- VFX: Beta Infected
+- VFX: Infected Beta
 - Config: Combo
 - Ammo Adjustment: None
     - Unlimited
@@ -531,7 +531,7 @@ The configurations that make up each of the custom weapons.
 - Weapon Type: M41 SPNKr + Rushdown Hammer
 - Trait Set: 40
     - Weapon Damage: 1.30
-- VFX: Alpha Infected
+- VFX: Infected Alpha
 - Config: Projectile
     - Shot Count: 2
     - Shot Velocity: 115
@@ -624,7 +624,7 @@ The configurations that make up each of the custom weapons.
 ## [47] Scorpion Shot
 - Weapon Type: Scorpion Tail
 - Trait Set: 47
-- VFX: Alpha Infected
+- VFX: Infected Alpha
 - Config: Default
 - Ammo Adjustment: -3.50
   - 04% (6 shots)
@@ -650,7 +650,7 @@ The configurations that make up each of the custom weapons.
 ## [49] Artifact Off Tremonius
 - Weapon Type: MLRS-2 Hydra + Ravager Rebound
 - Trait Set: 49
-- VFX: Beta Infected
+- VFX: Infected Beta
 - Config: Combo
 - Ammo Adjustment: None
     - 6+12


### PR DESCRIPTION
## Changes

**Adjusted:**

Equipment:
- [12] Power Arm:
    - Equipment Name: Power Arm -> **Allied Monitor**
    - Melee Recovery Speed: 1.80 -> **1.00 (none)**
    - **Third Person Gameplay: TRUE**
    - VFX: Infected Beta -> **VIP**
- [14] Headhunter Guard:
    - VFX: VIP -> **Infected Beta**

Ability Boosts:
- [3] Expert Marksman:
    - Melee Recovery Speed: 1.10 -> **1.40**

**Chores:**

- Adjusted name of Infected VFX in weapon configs.
- Fixed base weapon for [35] Cutlass Off Doomfruit

## Power Arm replacement

The [12] Power Arm was a powerup to increase melee recovery speed, making you melee faster, but we saw this powerup as the least ideal powerup due to its very situational use. Instead of buffing the powerup, we've done a complete rework of it and replaced it with a new powerup.

The new powerup called "Allied Monitor" makes the activating player enter a third-person camera view, which gives them a larger view of the battlefield. This extended view allows for gathering information while the user is still in cover. It can also be used to line up shots, which is an advantage when taking the first shot in a battle.

We've adjusted the VFX of the powerup from Infected Beta to VIP to indicate its [threat level](https://github.com/The-Scripters-Guild/Warzone/pull/59) more accordingly.

## Headhunter Guard threat level adjustment

Following the overhaul of the [12] Power Arm powerup to the Allied Monitor, and it's VFX adjustment, we've also changed the VFX on the [14] Headhunter Guard from VIP to Infected Beta to indicate its threat level better.

## Expert Marksman melee buff

After removing the increased melee recovery speed buff from the [12] Power Arm powerup by replacing the powerup, a vacancy was left for a way to increase the melee recovery speed via a powerup or ability boost.

We've increased the Melee Recovery Speed on the [3] Expert Marksman ability boost from 1.10 to 1.40 to fill this gap. We felt this change was fitting for the ability boost, as it was slightly lacking in the benefits it gave to the user. The Expert Marksman now is the ability boost players will want to equip if they're looking for the quickest melee speed combo.