### PR TITLE
0.6.9 - Chak 'Lok addition; Brute Berserker encounter update; Begin version reporting

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -111,6 +111,15 @@ Current state: Mode working fully, with some notable missing features:
 
 - Updated warzone-sandbox to 0.14.7
 
+### 0.6.9
+
+- Updated warzone-sandbox to 0.14.8
+- Added two new AI: [25] Boss Chak 'Lok & [26] Boss Hyperius
+- Added new AI Encounter: [12] Elite Encounter, Mythic.
+- Adjusted AI: [16] Brute Berserker, Chosen.
+- Adjusted AI Encounter: [7] Brute 2 Encounter, Legendary.
+- Added REQ scoring for capturing a zone (currently on-level).
+
 ## tsg warzone-sandbox library
 
 Changelog for the tsg warzone-sandbox library used for the sandbox scripting logic.

--- a/docs/npc/ai-variants-custom.md
+++ b/docs/npc/ai-variants-custom.md
@@ -286,6 +286,20 @@ Documentation of all the custom AI variants used for the Warzone mode. Only the 
     - Explosive Damage Scalar: 0.50
 - Notes: Is a Boss and has a health bar. Teleports around during combat. Has four stages of dealing damage to their shield, and then their health, before dying.
 
+## [25] Boss Chak 'Lok
+
+![AI preview](../../assets/ai-29.jpg)
+- Primary Weapon Type: MLRS-2 Hydra + Unbound Plasma Pistol ([48] Headhunter)
+- Secondary Weapon Type: Elite Bloodblade
+- Grenade Type: Plasma Grenade
+- Trait Set: BossChakLok
+  - Weapon Damage: 2.00
+  - Damage Resistance
+    - Direct Damage Scalar: 2.50
+    - Grenade Damage Scalar: 0.40
+    - Explosive Damage Scalar: 0.40
+- Notes: Activates shield only after engaging a target. Has an Active Camouflage equipment that they may use during an engagement.
+
 ## Acknowledgements
 
 Major research credit to cr0n14 (discord) for their [halo_infinite_unit_stats](https://docs.google.com/spreadsheets/d/e/2PACX-1vTZqdsTmPgdPCZT5IYoqvJrqbmKBLXzecmx3YP_aIejHypTw-Cxgwg9uwr_I7sImhhYVQq-agEt7xZO/pubhtml#) spreadsheet!

--- a/docs/npc/ai-variants-custom.md
+++ b/docs/npc/ai-variants-custom.md
@@ -187,14 +187,14 @@ Documentation of all the custom AI variants used for the Warzone mode. Only the 
 ## [16] Brute Berserker, Chosen
 
 ![AI preview](../../assets/ai-40.jpg)
-- Primary Weapon Type: CQS48 Bulldog + Diminisher of Hope ([12] Valor Off Dinh)
+- Primary Weapon Type: Brute Fists
 - Secondary Weapon Type: -
 - Trait Set: BruteBerserkerChosen
-  - Weapon Damage: 2.90
+  - Weapon Damage: 3.00
   - Damage Resistance
-    - Direct Damage Scalar: 4.30
-    - Grenade Damage Scalar: 0.2325
-    - Explosive Damage Scalar: 0.2325
+    - Direct Damage Scalar: 2.50
+    - Grenade Damage Scalar: 0.40
+    - Explosive Damage Scalar: 5.00
 - Notes: Is a Boss and has a health bar. Moves very fast and can one-hit melee a Spartan.
 
 ## [17] Brute Warrior
@@ -300,6 +300,16 @@ Documentation of all the custom AI variants used for the Warzone mode. Only the 
     - Explosive Damage Scalar: 0.40
 - Notes: Activates shield only after engaging a target. Has an Active Camouflage equipment that they may use during an engagement.
 
-## Acknowledgements
+## [26] Boss Hyperius
 
-Major research credit to cr0n14 (discord) for their [halo_infinite_unit_stats](https://docs.google.com/spreadsheets/d/e/2PACX-1vTZqdsTmPgdPCZT5IYoqvJrqbmKBLXzecmx3YP_aIejHypTw-Cxgwg9uwr_I7sImhhYVQq-agEt7xZO/pubhtml#) spreadsheet!
+![AI preview](../../assets/ai-61.jpg)
+- Primary Weapon Type: CQS48 Bulldog + Diminisher of Hope ([12] Valor Off Dinh)
+- Secondary Weapon Type: -
+- Grenade Type: Spike Grenade
+- Trait Set: BossHyperius
+  - Weapon Damage: 3.00
+  - Damage Resistance
+    - Direct Damage Scalar: 3.00
+    - Grenade Damage Scalar: 1.65
+    - Explosive Damage Scalar: 1.65
+- Notes: Has armor pieces that can be shot off to deal more damage to the unarmored areas. Has a jetpack that they can use to jump any length or height nav jump hint.

--- a/docs/npc/encounter-configs.md
+++ b/docs/npc/encounter-configs.md
@@ -116,9 +116,17 @@ The configurations of AI that make up each of the AI encounters.
 - Brute Warlord
 - Brute Warlord
 
-## [12] Unallocated
+## [12] Elite Encounter, Mythic
 
-- AI Name
+- Chak 'Lok (Boss)
+- Elite Warlord
+- Elite Warlord
+- Elite Warlord
+- Elite Ultra
+- Elite Ultra
+- Elite Ultra
+- Grunt Ultra
+- Grunt Ultra
 
 ## [13] Unallocated
 

--- a/docs/npc/encounter-configs.md
+++ b/docs/npc/encounter-configs.md
@@ -68,11 +68,10 @@ The configurations of AI that make up each of the AI encounters.
 ## [7] Brute 2 Encounter, Legendary
 
 - Brute Berserker, Chosen (Boss)
+- Boss Hyperius (Boss)
 - Brute Chieftain
-- Elite Ultra
 - Brute Warrior
 - Brute Warrior
-- Brute Sniper, Heavy
 - Jackal Raider
 
 ## [8] Hunter Encounter, Mythic

--- a/docs/version.md
+++ b/docs/version.md
@@ -1,0 +1,11 @@
+# Version
+
+Current version of Warzone and relevant scripting libraries.
+
+## Warzone
+
+0.6.9 (2025-07-19)
+
+## warzone-sandbox
+
+0.14.8 (2025-07-16)


### PR DESCRIPTION
## Changes


**Added**

AI:
- [25] Boss Chak 'Lok
- [26] Boss Hyperius

AI Encounters:
- [12] Elite Encounter, Mythic
	- Chak 'Lok (Boss)
	- Elite Warlord
	- Elite Warlord
	- Elite Warlord
	- Elite Ultra
	- Elite Ultra
	- Elite Ultra
	- Grunt Ultra
	- Grunt Ultra

**Adjusted:**

AI:
- [16] Brute Berserker, Chosen:
    - Primary Weapon Type: CQS48 Bulldog + Diminisher of Hope ([12] Valor Off Dinh) -> **Brute Fists**
    - Weapon Damage: 2.90 → **3.00**
    - Direct Damage Scalar: 4.30 → **2.50**
    - Grenade Damage Scalar: 0.2325 → **0.40**
    - Explosive Damage Scalar: 0.2325 → **5.00**

AI Encounters:
-  [7] Brute 2 Encounter, Legendary
	- Brute Berserker, Chosen (Boss)
	- → **Boss Hyperius (Boss)**
	- Brute Chieftain
	- → ~~Elite Ultra~~
	- Brute Warrior
	- Brute Warrior
	- → ~~Brute Sniper, Heavy~~
	- Jackal Raider

**Chores:**

- Added mode version file to docs.
- Updated Warzone and warzone-sandbox versions.

**Resolved issues:**
- https://github.com/The-Scripters-Guild/Warzone/issues/70
- https://github.com/The-Scripters-Guild/Warzone/issues/71
- https://github.com/The-Scripters-Guild/Warzone/issues/76

## Boss Chak 'Lok addition & Mythic Elite Encounter addition

Boss Chak 'Lok was added as the boss to a Mythic Elite encounter that requires strong shield-breaking weapons to defeat, and is a high threat for vehicles due to the Bosses EMP-capable weapon.

Chak 'Lok has an enormous shield count of 8750, making him have the most shield out of any AI. This means that players must prioritize plasma weapons to defeat this encounter. The boss is also exempt from the normal "headshot flag" meaning that even if their shield is broken, a single headshot from a precision weapon will not kill them.

Chak 'Lok mainly wields the [48] Headhunter, and only fires it in secondary fire which shoots a charged Unbound Plasma Pistol shot capable of killing a fully shielded Spartan in one hit to the head. The charge shot also causes an instant EMP to vehicles, which will immediately disable the vehicle, and usually rule it out of the fight as Chak 'Lok likes to shoot multiple shots at a disabled vehicle, usually destroying the vehicle in the process.

The encounter with Chak 'Lok requires players to first clear the fodder of high-ranking Elites and Grunts before even having a shot at targeting the main boss. These fodder are designed to keep the players away from the fight, and are also equipped with weapons that are strong against player shields and vehicles.

## Boss Hyperius addition, Brute Berserker, Chosen adjustment & Legendary Brute 2 Encounter adjustment

Following some observations about the boss of [7] Brute 2 Encounter, Legendary not shooting his weapon as much as we'd liked, we've added another boss to said encounter to accompany the Berserker Brute.

Boss Hyperius now takes the weapon ([12] Valor Off Dinh) of the Brute Berserker, Chosen, and the Berserker is given the default Brute Fists. We love the unique fear factor that the fast Berserker Brute evokes in players due to him being able to kill players in one melee hit, but were seeing that the Berserker Brute wasn't using his one-shot capable shotgun as much as we would've liked.

To remedy this, we've added a secondary boss–Hyperius–to the encounter to instead hold the coveted shotgun. Hyperius is not as fast as the Berserker Brute, but he holds a jetpack, which allows him to traverse anywhere AI are capable of, and he also is much more willing to make use of the shotgun.

As there are now two bosses in this encounter, we've adjusted their damage resistance values accordingly to split the total health between the two bosses evenly. We've also removed an Elite Ultra and a Brute Sniper, Heavy as this encounter focuses heavily on the two bosses instead of the fodder.